### PR TITLE
Fix/custom launch issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,9 @@ The above is taken from: https://keepachangelog.com/en/1.0.0/
 
 ### Unreleased
 
+- #56 [fix]     Action's 'take action' now open in webview and learning
+  resouces are checked off when clicked
+
 ### Version 1.1.3
 
 - #85 [change]  The style of the organisation page has been updated

--- a/lib/assets/routes/customLaunch.dart
+++ b/lib/assets/routes/customLaunch.dart
@@ -31,6 +31,7 @@ void customLaunch(
     );
   }
   else {
+    if (extraOnConfirmFunction != null) extraOnConfirmFunction();
     Navigator.of(context).pushNamed(Routes.webview, arguments: url);
   }
 }

--- a/lib/pages/action/ActionInfo.dart
+++ b/lib/pages/action/ActionInfo.dart
@@ -15,6 +15,7 @@ import 'package:app/assets/components/darkButton.dart';
 import 'package:app/assets/components/textButton.dart';
 import 'package:app/assets/components/customAppBar.dart';
 import 'package:app/assets/icons/customIcons.dart';
+import 'package:app/assets/routes/customLaunch.dart';
 
 import 'package:redux/redux.dart';
 import 'package:flutter_redux/flutter_redux.dart';
@@ -191,7 +192,7 @@ class _ActionInfoState extends State<ActionInfo> with WidgetsBindingObserver {
                       child: DarkButton("Take action",
                           style: DarkButtonStyles.Large,
                           inverted: true, onPressed: () {
-                        launch(_action.getLink());
+                        customLaunch(context, _action.getLink());
                       }),
                     ),
 


### PR DESCRIPTION
# Description

Please include a brief summary of what the issue is and what has been done to solve it
 Action's 'take action' now open in webview and learning resouces are checked off when clicked

Fixes #91 

# Checklist:

## Creator

- [x] The target branch is dev
- [x] I have updated the unreleased section of the change log
- [x] I have reviewed the 'files changed' tab on github to ensure all changes are as expected
- [ ] I have added someone to review the pr

## Reviewer

- [ ] I have verified the above are all completed
- [ ] I have run the code locally to ensure it fufills the requirements of the issue
- [ ] I have reviewed the 'files changed' and commented on any sections which I think are not needed, incorrect or could be improved

## After pull

- [ ] If appropriate I have closed the issue
