### PR TITLE
Use navigator for explore nav and update see cause link

### DIFF
--- a/lib/pages/Tabs.dart
+++ b/lib/pages/Tabs.dart
@@ -1,3 +1,7 @@
+import 'package:app/locator.dart';
+import 'package:app/services/navigation_service.dart';
+import 'package:app/viewmodels/explore_page_view_model.dart';
+import 'package:app/viewmodels/tabs_view_model.dart';
 import 'package:flutter/material.dart';
 
 import 'package:app/assets/icons/customIcons.dart';
@@ -5,11 +9,9 @@ import 'package:app/assets/icons/customIcons.dart';
 import 'package:app/pages/home/Home.dart';
 import 'package:app/pages/more/MoreMenu.dart';
 import 'package:app/pages/explore/ExplorePage.dart';
+import 'package:stacked/stacked.dart';
 
-//import 'package:app/assets/dynamicLinks.dart';
-
-// These must be in the corect order
-enum TabPage { Home, Explore, Menu }
+export 'package:app/viewmodels/tabs_view_model.dart';
 
 class TabPageDetails {
   final Widget widget;
@@ -20,37 +22,17 @@ class TabPageDetails {
       {required this.widget, required this.icon, required this.title});
 }
 
-class TabsPage extends StatefulWidget {
-  final TabPage currentPage;
-  final dynamic arguments;
-
-  TabsPage({required this.currentPage, this.arguments});
-
-  @override
-  _TabsPageState createState() => _TabsPageState();
+class TabsPageArguments {
+  final TabPage? initialPage;
+  final ExplorePageArguments? explorePageArgs;
+  
+  TabsPageArguments({this.initialPage, this.explorePageArgs});
 }
 
-class _TabsPageState extends State<TabsPage> with WidgetsBindingObserver {
-  late TabPage currentPage;
+class TabsPage extends StatelessWidget with WidgetsBindingObserver {
+  final TabsPageArguments args;
 
-  @override
-  void initState() {
-    currentPage = widget.currentPage;
-    super.initState();
-    WidgetsBinding.instance.addObserver(this);
-  }
-
-  @override
-  void dispose() {
-    WidgetsBinding.instance.removeObserver(this);
-    super.dispose();
-  }
-
-  void changePage(TabPage page, {int? subIndex}) {
-    setState(() {
-      currentPage = page;
-    });
-  }
+  TabsPage(this.args);
 
   @override
   Widget build(BuildContext context) {
@@ -61,7 +43,7 @@ class _TabsPageState extends State<TabsPage> with WidgetsBindingObserver {
         title: "Home",
       ),
       TabPage.Explore: TabPageDetails(
-        widget: home_explore_page,
+        widget: ExplorePage(args.explorePageArgs != null ? args.explorePageArgs! : home_explore_page),
         icon: CustomIcons.ic_news,
         title: "Explore",
       ),
@@ -94,27 +76,29 @@ class _TabsPageState extends State<TabsPage> with WidgetsBindingObserver {
     }
 
     return WillPopScope(
-        onWillPop: () async => false,
-        child: Scaffold(
-          body: _pages[currentPage]!.widget,
-          bottomNavigationBar: BottomNavigationBar(
-            currentIndex: currentPage.index,
-            type: BottomNavigationBarType.fixed,
-            elevation: 3,
-            iconSize: 25,
-            unselectedLabelStyle: TextStyle(
-                color: Color.fromRGBO(155, 159, 177, 1), fontSize: 10),
-            unselectedItemColor: Color.fromRGBO(155, 159, 177, 1),
-            selectedItemColor: Theme.of(context).primaryColor,
-            selectedIconTheme: IconThemeData(color: Colors.white),
-            selectedLabelStyle: TextStyle(fontSize: 12),
-            items: generateBottomNavBarItems(),
-            onTap: (index) {
-              setState(() {
-                currentPage = TabPage.values[index];
-              });
-            },
-          ),
-        ));
+        onWillPop: () async => locator<NavigationService>().canGoBack(),
+        child: ViewModelBuilder<TabsViewModel>.reactive(
+          viewModelBuilder: () => TabsViewModel(args.initialPage),
+          builder: (context, model, child) {
+            return Scaffold(
+              body: _pages[model.currentPage]!.widget,
+              bottomNavigationBar: BottomNavigationBar(
+                currentIndex: model.currentPage.index,
+                type: BottomNavigationBarType.fixed,
+                elevation: 3,
+                iconSize: 25,
+                unselectedLabelStyle: TextStyle(
+                    color: Color.fromRGBO(155, 159, 177, 1), fontSize: 10),
+                unselectedItemColor: Color.fromRGBO(155, 159, 177, 1),
+                selectedItemColor: Theme.of(context).primaryColor,
+                selectedIconTheme: IconThemeData(color: Colors.white),
+                selectedLabelStyle: TextStyle(fontSize: 12),
+                items: generateBottomNavBarItems(),
+                onTap: (index) => model.setPage(TabPage.values[index]),
+              ),
+            );
+          },
+        )
+    );
   }
 }

--- a/lib/pages/Tabs.dart
+++ b/lib/pages/Tabs.dart
@@ -25,7 +25,7 @@ class TabPageDetails {
 class TabsPageArguments {
   final TabPage? initialPage;
   final ExplorePageArguments? explorePageArgs;
-  
+
   TabsPageArguments({this.initialPage, this.explorePageArgs});
 }
 
@@ -43,7 +43,9 @@ class TabsPage extends StatelessWidget with WidgetsBindingObserver {
         title: "Home",
       ),
       TabPage.Explore: TabPageDetails(
-        widget: ExplorePage(args.explorePageArgs != null ? args.explorePageArgs! : home_explore_page),
+        widget: ExplorePage(args.explorePageArgs != null
+            ? args.explorePageArgs!
+            : home_explore_page),
         icon: CustomIcons.ic_news,
         title: "Explore",
       ),
@@ -98,7 +100,6 @@ class TabsPage extends StatelessWidget with WidgetsBindingObserver {
               ),
             );
           },
-        )
-    );
+        ));
   }
 }

--- a/lib/pages/action/ActionInfo.dart
+++ b/lib/pages/action/ActionInfo.dart
@@ -108,20 +108,16 @@ class _ActionInfoState extends State<ActionInfo> with WidgetsBindingObserver {
                                     ],
                                   ),
                                   GestureDetector(
-                                      onTap: () {
-                                        // TODO This must go to the causes info page
-                                        // For now this can be the home explore page filtered by a single cause
-                                        Navigator.of(context).pushNamed(
-                                            Routes.home,
-                                            arguments: model.action!.cause.id);
-                                      },
+                                      // TODO This must go to the causes info page
+                                      // For now this can be the home explore page filtered by a single cause
+                                      onTap: model.navigateToCauseExplorePage,
                                       child: Container(
                                         height: 20,
                                         child: Padding(
                                           padding: EdgeInsets.symmetric(
                                               horizontal: 5),
                                           child: Text(
-                                            "See the campaign",
+                                            "See cause",
                                             style: textStyleFrom(
                                               Theme.of(context)
                                                   .primaryTextTheme

--- a/lib/pages/explore/ExplorePage.dart
+++ b/lib/pages/explore/ExplorePage.dart
@@ -59,7 +59,8 @@ class ExplorePage extends StatelessWidget {
                   child: ListView(
                       scrollDirection: Axis.horizontal,
                       shrinkWrap: true,
-                      padding: EdgeInsets.symmetric(horizontal: horizontalPadding),
+                      padding:
+                          EdgeInsets.symmetric(horizontal: horizontalPadding),
                       // Map section arguments into real sections
                       children: model.sections
                           .where((section) => section.args.link != null)

--- a/lib/pages/explore/ExplorePage.dart
+++ b/lib/pages/explore/ExplorePage.dart
@@ -9,49 +9,71 @@ import 'package:stacked/stacked.dart';
 final double horizontalPadding = CustomPaddingSize.small;
 
 class ExplorePage extends StatelessWidget {
-  final List<ExploreSection> sections;
-  final String title;
+  final ExplorePageArguments args;
 
-  ExplorePage({required this.sections, required this.title, Key? key})
-      : super(key: key);
+  ExplorePage(this.args, {Key? key}) : super(key: key);
+
+  List<ExploreSection> buildSections() {
+    return this.args.sections.map((sectionArgs) {
+      switch (sectionArgs.type) {
+        case ExploreSectionType.Action:
+          return ActionExploreSection(sectionArgs);
+        case ExploreSectionType.Learning:
+          return LearningResourceExploreSection(sectionArgs);
+        case ExploreSectionType.Campaign:
+          return CampaignExploreSection(sectionArgs);
+        case ExploreSectionType.News:
+          return NewsExploreSection(sectionArgs);
+      }
+    }).toList() as List<ExploreSection>;
+  }
 
   Widget _header(BuildContext context, ExplorePageViewModel model) {
     return SafeArea(
         child: Padding(
-      padding:
-          EdgeInsets.symmetric(horizontal: horizontalPadding, vertical: 20),
+      padding: EdgeInsets.symmetric(vertical: 20),
       child: Column(
         children: [
           GestureDetector(
-            onTap: model.canBack ? () => model.back() : null,
-            child: Row(
-              mainAxisAlignment: MainAxisAlignment.start,
-              children: [
-                if (model.canBack) Icon(Icons.chevron_left, size: 30),
-                Text(
-                  model.title,
-                  style: exploreHeading,
-                  textAlign: TextAlign.left,
-                ),
-              ],
+            onTap: model.canGoBack ? model.back : null,
+            child: Padding(
+              padding: EdgeInsets.symmetric(horizontal: horizontalPadding),
+              child: Row(
+                mainAxisAlignment: MainAxisAlignment.start,
+                children: [
+                  if (model.canGoBack) Icon(Icons.chevron_left, size: 30),
+                  Text(
+                    model.title,
+                    style: exploreHeading,
+                    textAlign: TextAlign.left,
+                  ),
+                ],
+              ),
             ),
           ),
-          Container(
-              height: 50,
-              child: ListView(
-                  scrollDirection: Axis.horizontal,
-                  shrinkWrap: true,
-                  children: model.sections
-                      .where((section) => section.link != null)
-                      .map((section) => Padding(
-                            padding: const EdgeInsets.all(4.0),
-                            child: DarkButton(
-                              section.title,
-                              onPressed: () => model.changePage(section.link!),
-                              size: DarkButtonSize.Large,
-                            ),
-                          ))
-                      .toList()))
+          if (model.hasLinks())
+            Padding(
+              padding: EdgeInsets.only(top: 10),
+              child: Container(
+                  height: 50,
+                  child: ListView(
+                      scrollDirection: Axis.horizontal,
+                      shrinkWrap: true,
+                      padding: EdgeInsets.symmetric(horizontal: horizontalPadding),
+                      // Map section arguments into real sections
+                      children: model.sections
+                          .where((section) => section.args.link != null)
+                          .map((section) => Padding(
+                                padding: const EdgeInsets.all(4.0),
+                                child: DarkButton(
+                                  section.args.title,
+                                  onPressed: () =>
+                                      model.changePage(section.args.link!),
+                                  size: DarkButtonSize.Large,
+                                ),
+                              ))
+                          .toList())),
+            )
         ],
       ),
     ));
@@ -60,7 +82,8 @@ class ExplorePage extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return ViewModelBuilder<ExplorePageViewModel>.reactive(
-        viewModelBuilder: () => ExplorePageViewModel(title, sections),
+        viewModelBuilder: () => ExplorePageViewModel(args.title, args.sections,
+            baseParams: args.baseParams),
         onModelReady: (model) => model.init(),
         builder: (context, model, child) {
           return Scaffold(
@@ -81,109 +104,136 @@ class ExplorePage extends StatelessWidget {
   }
 }
 
-ExplorePage campaigns_explore_page = ExplorePage(title: "Campaigns", sections: [
-  CampaignExploreSection(title: "Campaigns of the month", baseParams: {
-    "of_the_month": true,
-  }),
-  CampaignExploreSection(title: "Recommended campaigns", baseParams: {
-    "recommended": true,
-  }),
-  CampaignExploreSection(
+ExplorePageArguments campaigns_explore_page =
+    ExplorePageArguments(title: "Campaigns", sections: [
+  ExploreSectionArguments(
+      title: "Campaigns of the month",
+      baseParams: {
+        "of_the_month": true,
+      },
+      type: ExploreSectionType.Campaign),
+  ExploreSectionArguments(
+      title: "Recommended campaigns",
+      baseParams: {
+        "recommended": true,
+      },
+      type: ExploreSectionType.Campaign),
+  ExploreSectionArguments(
     title: "Campaigns by cause",
     filter: ByCauseExploreFilter(),
+    type: ExploreSectionType.Campaign,
   ),
-  CampaignExploreSection(
+  ExploreSectionArguments(
     title: "Completed campaigns",
     baseParams: {
       "completed": true,
     },
     backgroundColor: CustomColors.lightOrange,
+    type: ExploreSectionType.Campaign,
   ),
 ]);
 
-ExplorePage actions_explore_page = ExplorePage(
+ExplorePageArguments actions_explore_page = ExplorePageArguments(
   title: "Actions",
   sections: [
-    ActionExploreSection(title: "Actions of the month", baseParams: {
-      "of_the_month": true,
-    }),
-    ActionExploreSection(
+    ExploreSectionArguments(
+        title: "Actions of the month",
+        baseParams: {
+          "of_the_month": true,
+        },
+        type: ExploreSectionType.Action),
+    ExploreSectionArguments(
       title: "Actions by cause",
       filter: ByCauseExploreFilter(),
+      type: ExploreSectionType.Action,
     ),
-    ActionExploreSection(
+    ExploreSectionArguments(
       title: "Actions by time",
       filter: TimeExploreFilter(),
+      type: ExploreSectionType.Action,
     ),
-    ActionExploreSection(
-        title: "Actions by type",
-        filter: ExploreFilter(
-          parameterName: "type",
-          multi: false,
-          options: actionTypes
-              .map((type) => ExploreFilterOption(
-                    displayName: type.name,
-                    parameterValue: type.name,
-                  ))
-              .toList(),
-        )),
-    ActionExploreSection(
+    ExploreSectionArguments(
+      title: "Actions by type",
+      filter: ExploreFilter(
+        parameterName: "type",
+        multi: false,
+        options: actionTypes
+            .map((type) => ExploreFilterOption(
+                  displayName: type.name,
+                  parameterValue: type.name,
+                ))
+            .toList(),
+      ),
+      type: ExploreSectionType.Action,
+    ),
+    ExploreSectionArguments(
       title: "Completed actions",
       baseParams: {
         "completed": true,
       },
       backgroundColor: CustomColors.lightOrange,
+      type: ExploreSectionType.Action,
     ),
   ],
 );
 
-ExplorePage learning_explore_page = ExplorePage(
+ExplorePageArguments learning_explore_page = ExplorePageArguments(
   title: "Learn",
   sections: [
-    LearningResourceExploreSection(
+    ExploreSectionArguments(
       title: "Learning resources by time",
       filter: TimeExploreFilter(),
+      type: ExploreSectionType.Learning,
     ),
-    LearningResourceExploreSection(
+    ExploreSectionArguments(
       title: "Learning resource by cause",
       filter: ByCauseExploreFilter(),
+      type: ExploreSectionType.Learning,
     ),
-    LearningResourceExploreSection(title: "Learning resources"),
-    LearningResourceExploreSection(
+    ExploreSectionArguments(
+      title: "Learning resources",
+      type: ExploreSectionType.Learning,
+    ),
+    ExploreSectionArguments(
       title: "Completed learning",
       baseParams: {
         "completed": true,
       },
       backgroundColor: CustomColors.lightOrange,
+      type: ExploreSectionType.Learning,
     ),
   ],
 );
 
-ExplorePage home_explore_page = ExplorePage(
+ExplorePageArguments home_explore_page = ExplorePageArguments(
   title: "Explore",
   sections: [
-    ActionExploreSection(
+    ExploreSectionArguments(
       title: "Actions",
       link: actions_explore_page,
       description:
           "Take a wide range of actions to drive lasting change for issues you care about",
+      type: ExploreSectionType.Action,
     ),
-    LearningResourceExploreSection(
+    ExploreSectionArguments(
       title: "Learn",
       link: learning_explore_page,
       description:
           "Learn more about key topics of pressing social and environmental issues",
+      type: ExploreSectionType.Learning,
     ),
-    CampaignExploreSection(
+    ExploreSectionArguments(
       title: "Campaigns",
       link: campaigns_explore_page,
       description:
           "Join members of the now-u community in coordinated campaigns to make a difference",
+      type: ExploreSectionType.Campaign,
     ),
-    NewsExploreSection(
+    ExploreSectionArguments(
       title: "News",
       description:
           "Find out what’s going on in the world this week in relation to your chosen causes",
+      type: ExploreSectionType.News,
     ),
   ],
 );

--- a/lib/pages/explore/ExploreSection.dart
+++ b/lib/pages/explore/ExploreSection.dart
@@ -39,7 +39,7 @@ class ExploreFilterSelectionItem extends StatelessWidget {
 
 class ExploreSectionWidget extends StatelessWidget {
   final ExploreSection data;
-  final Function(ExplorePage page) changePage;
+  final Function(ExplorePageArguments page) changePage;
   final Function(BaseExploreFilterOption option) toggleFilterOption;
 
   ExploreSectionWidget({
@@ -61,22 +61,22 @@ class ExploreSectionWidget extends StatelessWidget {
       child: Column(
         children: [
           GestureDetector(
-            onTap: data.link != null ? () => changePage(data.link!) : () {},
+            onTap: data.args.link != null ? () => changePage(data.args.link!) : () {},
             child: Row(
               mainAxisAlignment: MainAxisAlignment.start,
               children: [
                 Text(
-                  data.title,
+                  data.args.title,
                   style: Theme.of(context).primaryTextTheme.headline3,
                   textAlign: TextAlign.left,
                 ),
-                if (data.link != null) Icon(Icons.chevron_right, size: 30)
+                if (data.args.link != null) Icon(Icons.chevron_right, size: 30)
               ],
             ),
           ),
-          if (data.description != null)
+          if (data.args.description != null)
             Text(
-              data.description!,
+              data.args.description!,
               style: Theme.of(context).primaryTextTheme.headline4,
               textAlign: TextAlign.left,
             ),
@@ -129,7 +129,7 @@ class ExploreSectionWidget extends StatelessWidget {
               ),
               SizedBox(height: CustomPaddingSize.small),
               Text(
-                "Looks like we don’t have any ‘${data.title}’ to recommend right now. Check out our ‘Explore’ page to get involved another way.",
+                "Looks like we don’t have any ‘${data.args.title}’ to recommend right now. Check out our ‘Explore’ page to get involved another way.",
                 style: lightTheme.textTheme.bodyMedium,
                 textAlign: TextAlign.center,
               ),
@@ -183,9 +183,9 @@ class ExploreSectionWidget extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Container(
-        color: data.backgroundColor,
+        color: data.args.backgroundColor,
         child: Padding(
-          padding: EdgeInsets.only(top: data.backgroundColor != null ? 12 : 0),
+          padding: EdgeInsets.only(top: data.args.backgroundColor != null ? 12 : 0),
           child: Column(
             crossAxisAlignment: CrossAxisAlignment.start,
             children: <Widget>[

--- a/lib/pages/explore/ExploreSection.dart
+++ b/lib/pages/explore/ExploreSection.dart
@@ -61,7 +61,9 @@ class ExploreSectionWidget extends StatelessWidget {
       child: Column(
         children: [
           GestureDetector(
-            onTap: data.args.link != null ? () => changePage(data.args.link!) : () {},
+            onTap: data.args.link != null
+                ? () => changePage(data.args.link!)
+                : () {},
             child: Row(
               mainAxisAlignment: MainAxisAlignment.start,
               children: [
@@ -185,7 +187,8 @@ class ExploreSectionWidget extends StatelessWidget {
     return Container(
         color: data.args.backgroundColor,
         child: Padding(
-          padding: EdgeInsets.only(top: data.args.backgroundColor != null ? 12 : 0),
+          padding:
+              EdgeInsets.only(top: data.args.backgroundColor != null ? 12 : 0),
           child: Column(
             crossAxisAlignment: CrossAxisAlignment.start,
             children: <Widget>[

--- a/lib/pages/home/Home.dart
+++ b/lib/pages/home/Home.dart
@@ -39,16 +39,10 @@ class Home extends StatelessWidget {
                     : HeaderStyle1(name: model.currentUser!.getName()),
                 children: [
                   Column(children: <Widget>[
-                    // Campaigns
-                    ProgressTile(
-                      campaignsScore: model.numberOfCompletedCampaigns,
-                      actionsScore: model.numberOfCompletedActions,
-                      learningsScore: model.numberOfCompletedLearningResources,
-                    ),
-
-                    SizedBox(height: 30),
-                    ExploreSectionWidget.fromModel(model.myCampaigns, model),
+                    SizedBox(height: 10,),
                     ExploreSectionWidget.fromModel(model.myActions, model),
+                    ExploreSectionWidget.fromModel(
+                        model.suggestedCampaigns, model),
                     CustomWidthButton(
                       'Explore',
                       onPressed: () {
@@ -60,8 +54,16 @@ class Home extends StatelessWidget {
                       buttonWidthProportion: 0.8,
                     ),
                     SizedBox(height: 30),
-                    ExploreSectionWidget.fromModel(
-                        model.suggestedCampaigns, model),
+
+                    // Campaigns
+                    ProgressTile(
+                      campaignsScore: model.numberOfCompletedCampaigns,
+                      actionsScore: model.numberOfCompletedActions,
+                      learningsScore: model.numberOfCompletedLearningResources,
+                    ),
+
+                    SizedBox(height: 30),
+                    ExploreSectionWidget.fromModel(model.myCampaigns, model),
                     ExploreSectionWidget.fromModel(model.inTheNews, model),
 
                     Padding(

--- a/lib/pages/home/Home.dart
+++ b/lib/pages/home/Home.dart
@@ -39,7 +39,9 @@ class Home extends StatelessWidget {
                     : HeaderStyle1(name: model.currentUser!.getName()),
                 children: [
                   Column(children: <Widget>[
-                    SizedBox(height: 10,),
+                    SizedBox(
+                      height: 10,
+                    ),
                     ExploreSectionWidget.fromModel(model.myActions, model),
                     ExploreSectionWidget.fromModel(
                         model.suggestedCampaigns, model),

--- a/lib/routes.dart
+++ b/lib/routes.dart
@@ -17,6 +17,7 @@ import 'package:app/pages/causes/ChangeCausePage.dart';
 import 'package:app/pages/other/InfoPage.dart';
 import 'package:app/pages/other/NotificationPage.dart';
 import 'package:app/pages/other/OrganisationPage.dart';
+import 'package:app/viewmodels/explore_page_view_model.dart';
 import 'package:flutter/material.dart';
 
 class Routes {
@@ -123,13 +124,13 @@ Function initRoutes = (RouteSettings settings) {
     case Routes.home:
       {
         return customRoute(
-            builder: (context) => TabsPage(currentPage: TabPage.Home),
+            builder: (context) => TabsPage(TabsPageArguments(initialPage: TabPage.Home)),
             settings: settings);
       }
     case Routes.explore:
       {
         return customRoute(
-            builder: (context) => TabsPage(currentPage: TabPage.Explore),
+            builder: (context) => TabsPage(TabsPageArguments(initialPage: TabPage.Explore, explorePageArgs: args is ExplorePageArguments ? args : null)),
             settings: settings);
       }
     case Routes.campaign:
@@ -157,7 +158,7 @@ Function initRoutes = (RouteSettings settings) {
               builder: (context) => InfoPage(args), settings: settings);
         }
         return customRoute(
-            builder: (context) => TabsPage(currentPage: TabPage.Home),
+            builder: (context) => TabsPage(TabsPageArguments(initialPage: TabPage.Home)),
             settings: settings);
       }
     // Other
@@ -185,7 +186,7 @@ Function initRoutes = (RouteSettings settings) {
     default:
       {
         return customRoute(
-            builder: (context) => TabsPage(currentPage: TabPage.Home),
+            builder: (context) => TabsPage(TabsPageArguments(initialPage: TabPage.Home)),
             settings: settings);
       }
   }

--- a/lib/routes.dart
+++ b/lib/routes.dart
@@ -124,13 +124,16 @@ Function initRoutes = (RouteSettings settings) {
     case Routes.home:
       {
         return customRoute(
-            builder: (context) => TabsPage(TabsPageArguments(initialPage: TabPage.Home)),
+            builder: (context) =>
+                TabsPage(TabsPageArguments(initialPage: TabPage.Home)),
             settings: settings);
       }
     case Routes.explore:
       {
         return customRoute(
-            builder: (context) => TabsPage(TabsPageArguments(initialPage: TabPage.Explore, explorePageArgs: args is ExplorePageArguments ? args : null)),
+            builder: (context) => TabsPage(TabsPageArguments(
+                initialPage: TabPage.Explore,
+                explorePageArgs: args is ExplorePageArguments ? args : null)),
             settings: settings);
       }
     case Routes.campaign:
@@ -158,7 +161,8 @@ Function initRoutes = (RouteSettings settings) {
               builder: (context) => InfoPage(args), settings: settings);
         }
         return customRoute(
-            builder: (context) => TabsPage(TabsPageArguments(initialPage: TabPage.Home)),
+            builder: (context) =>
+                TabsPage(TabsPageArguments(initialPage: TabPage.Home)),
             settings: settings);
       }
     // Other
@@ -186,7 +190,8 @@ Function initRoutes = (RouteSettings settings) {
     default:
       {
         return customRoute(
-            builder: (context) => TabsPage(TabsPageArguments(initialPage: TabPage.Home)),
+            builder: (context) =>
+                TabsPage(TabsPageArguments(initialPage: TabPage.Home)),
             settings: settings);
       }
   }

--- a/lib/services/navigation_service.dart
+++ b/lib/services/navigation_service.dart
@@ -48,13 +48,20 @@ class NavigationService {
 
   NavigationService(this.navigatorKey, this.urlLauncher, this.browser);
 
-  Future<dynamic> navigateTo(String routeName, {arguments}) {
+  Future<dynamic> navigateTo(String routeName, {arguments, clearHistory = false}) {
+    if (clearHistory) {
+      return navigatorKey.currentState!.pushNamedAndRemoveUntil(routeName, (route) => false, arguments: arguments);
+    }
     return navigatorKey.currentState!
         .pushNamed(routeName, arguments: arguments);
   }
-
+  
   void goBack() {
     return navigatorKey.currentState!.pop();
+  }
+
+  bool canGoBack() {
+    return navigatorKey.currentState!.canPop();
   }
 
   bool isInternalLink(String link) {

--- a/lib/services/navigation_service.dart
+++ b/lib/services/navigation_service.dart
@@ -48,14 +48,17 @@ class NavigationService {
 
   NavigationService(this.navigatorKey, this.urlLauncher, this.browser);
 
-  Future<dynamic> navigateTo(String routeName, {arguments, clearHistory = false}) {
+  Future<dynamic> navigateTo(String routeName,
+      {arguments, clearHistory = false}) {
     if (clearHistory) {
-      return navigatorKey.currentState!.pushNamedAndRemoveUntil(routeName, (route) => false, arguments: arguments);
+      return navigatorKey.currentState!.pushNamedAndRemoveUntil(
+          routeName, (route) => false,
+          arguments: arguments);
     }
     return navigatorKey.currentState!
         .pushNamed(routeName, arguments: arguments);
   }
-  
+
   void goBack() {
     return navigatorKey.currentState!.pop();
   }

--- a/lib/viewmodels/action_info_model.dart
+++ b/lib/viewmodels/action_info_model.dart
@@ -1,3 +1,5 @@
+import 'package:app/models/Cause.dart';
+import 'package:app/pages/explore/ExplorePage.dart';
 import 'package:app/services/causes_service.dart';
 import 'package:app/services/dialog_service.dart';
 import 'package:app/viewmodels/base_model.dart';
@@ -7,6 +9,7 @@ import 'package:app/routes.dart';
 import 'package:app/services/navigation_service.dart';
 
 import 'package:app/models/Action.dart';
+import 'package:app/viewmodels/explore_page_view_model.dart';
 
 class ActionInfoViewModel extends BaseModel {
   final NavigationService _navigationService = locator<NavigationService>();
@@ -46,5 +49,10 @@ class ActionInfoViewModel extends BaseModel {
 
   void launchAction() {
     _navigationService.launchLink(_action!.link!);
+  }
+
+  void navigateToCauseExplorePage() {
+    ListCause cause = this.action!.cause;
+    _navigationService.navigateTo(Routes.explore, arguments: ExplorePageArguments(sections: home_explore_page.sections, title: "Explore ${cause.title} cause", baseParams: { "cause__in": [this.action!.cause.id] }));
   }
 }

--- a/lib/viewmodels/action_info_model.dart
+++ b/lib/viewmodels/action_info_model.dart
@@ -53,6 +53,12 @@ class ActionInfoViewModel extends BaseModel {
 
   void navigateToCauseExplorePage() {
     ListCause cause = this.action!.cause;
-    _navigationService.navigateTo(Routes.explore, arguments: ExplorePageArguments(sections: home_explore_page.sections, title: "Explore ${cause.title} cause", baseParams: { "cause__in": [this.action!.cause.id] }));
+    _navigationService.navigateTo(Routes.explore,
+        arguments: ExplorePageArguments(
+            sections: home_explore_page.sections,
+            title: "Explore ${cause.title} cause",
+            baseParams: {
+              "cause__in": [this.action!.cause.id]
+            }));
   }
 }

--- a/lib/viewmodels/explore_page_view_model.dart
+++ b/lib/viewmodels/explore_page_view_model.dart
@@ -391,7 +391,7 @@ class ExplorePageViewModel extends BaseModel with ExploreViewModelMixin {
 
   bool hasLinks() {
     return sections.any((section) => section.args.link != null);
-  } 
+  }
 }
 
 //-- Explore Sections --//

--- a/lib/viewmodels/explore_page_view_model.dart
+++ b/lib/viewmodels/explore_page_view_model.dart
@@ -6,17 +6,79 @@ import 'package:app/models/Campaign.dart';
 import 'package:app/models/Cause.dart';
 import 'package:app/models/Learning.dart';
 import 'package:app/models/article.dart';
+import 'package:app/routes.dart';
 import 'package:app/services/auth.dart';
+import 'package:app/services/navigation_service.dart';
 import 'package:app/services/news_service.dart';
 import 'package:equatable/equatable.dart';
 import 'package:collection/collection.dart';
 import 'package:flutter/material.dart';
 
-import 'package:app/pages/explore/ExplorePage.dart';
 import 'package:app/viewmodels/base_model.dart';
 import 'package:app/models/Explorable.dart';
 import 'package:app/locator.dart';
 import 'package:app/services/causes_service.dart';
+
+class ExplorePageArguments {
+  final List<ExploreSectionArguments> sections;
+  final String title;
+  final Map<String, dynamic>? baseParams;
+
+  ExplorePageArguments(
+      {required this.sections, required this.title, this.baseParams});
+
+  ExplorePageArguments addBaseParams(Map<String, dynamic> baseParams) {
+    return ExplorePageArguments(
+        sections: sections,
+        title: title,
+        baseParams: mergeMaps(baseParams, this.baseParams ?? {}));
+  }
+}
+
+class ExploreSectionArguments {
+  /// Title of the section
+  final String title;
+
+  /// Where clicking on the title should go
+  final ExplorePageArguments? link;
+
+  /// Description of the section
+  final String? description;
+
+  // Params to provide to fetch query
+  final Map<String, dynamic>? baseParams;
+
+  ///
+  final BaseExploreFilter? filter;
+
+  final Color? backgroundColor;
+
+  final ExploreSectionType type;
+
+  ExploreSectionArguments({
+    required this.title,
+    required this.type,
+    this.description,
+    this.link,
+    this.baseParams,
+    this.filter,
+    this.backgroundColor,
+  });
+
+  ExploreSectionArguments addBaseParams(Map<String, dynamic> baseParams) {
+    return ExploreSectionArguments(
+      title: title,
+      // TODO This doesnt quite work as we also need to update the title
+      // link: link != null ? link!.addBaseParams(baseParams) : null,
+      link: link,
+      description: description,
+      baseParams: mergeMaps(baseParams, this.baseParams ?? {}),
+      filter: filter,
+      backgroundColor: backgroundColor,
+      type: type,
+    );
+  }
+}
 
 abstract class BaseExploreFilterOption extends Equatable {
   /// What is displayed to the user
@@ -210,48 +272,38 @@ enum ExploreSectionState {
   Loaded,
 }
 
+enum ExploreSectionType {
+  Action,
+  Learning,
+  Campaign,
+  News,
+}
+
 abstract class ExploreSection<T extends Explorable> {
   CausesService _causesService = locator<CausesService>();
   AuthenticationService _authService = locator<AuthenticationService>();
 
   final double tileHeight = 160;
-  final Color? backgroundColor;
 
+  List<T>? tiles;
   Future<List<T>> fetchTiles(Map<String, dynamic> params);
   Widget renderTile(T tile);
 
-  ExploreSection({
-    required this.title,
-    this.description,
-    this.link,
-    this.baseParams,
-    this.filter,
+  BaseExploreFilter? get filter => this.args.filter;
+
+  ExploreSection(
+    this.args, {
     this.state = ExploreSectionState.Loading,
-    this.backgroundColor,
   });
 
-  /// Title of the section
-  String title;
-
-  /// Where clicking on the title should go
-  ExplorePage? link;
-
-  /// Description of the section
-  String? description;
-
-  // Params to provide to fetch query
-  Map<String, dynamic>? baseParams;
-
-  ///
-  BaseExploreFilter? filter;
-  List<T>? tiles;
-
+  final ExploreSectionArguments args;
   ExploreSectionState state = ExploreSectionState.Loading;
 
   Map<String, dynamic> get queryParams {
-    Map<String, dynamic> params =
-        mergeMaps(baseParams ?? {}, filter != null ? filter!.toJson() : {});
+    Map<String, dynamic> params = mergeMaps(args.baseParams ?? {},
+        args.filter != null ? args.filter!.toJson() : {});
     // By default all sections should be filtered by the user's selected causes
+    print("Getting params ${params}");
     if (!params.containsKey("cause__in") && _authService.currentUser != null) {
       params["cause__in"] = _authService.currentUser!.selectedCauseIds;
     }
@@ -270,8 +322,8 @@ abstract class ExploreSection<T extends Explorable> {
   void reload(Function notifyListeners) async {
     state = ExploreSectionState.Loading;
     notifyListeners();
-    if (filter != null) {
-      await filter!.init(notifyListeners);
+    if (args.filter != null) {
+      await args.filter!.init(notifyListeners);
     }
     tiles = await fetchTiles(queryParams);
     state = ExploreSectionState.Loaded;
@@ -296,51 +348,50 @@ mixin ExploreViewModelMixin on BaseModel {
   }
 }
 
+ExploreSection exploreSectionFromArgs(ExploreSectionArguments args) {
+  switch (args.type) {
+    case ExploreSectionType.Campaign:
+      return CampaignExploreSection(args);
+    case ExploreSectionType.Learning:
+      return LearningResourceExploreSection(args);
+    case ExploreSectionType.Action:
+      return ActionExploreSection(args);
+    case ExploreSectionType.News:
+      return NewsExploreSection(args);
+  }
+}
+
 class ExplorePageViewModel extends BaseModel with ExploreViewModelMixin {
-  String title;
+  NavigationService _navigationService = locator<NavigationService>();
+  final String title;
 
   void init() {
     initSections();
   }
 
-  final Queue<ExplorePage> previousPages = Queue();
-
-  ExplorePageViewModel(this.title, List<ExploreSection> sections) {
-    print("Sections are $sections");
-    this.sections = sections;
+  ExplorePageViewModel(this.title, List<ExploreSectionArguments> sections,
+      {Map<String, dynamic>? baseParams}) {
+    // Add the base parameters to the sections
+    this.sections = sections.map((args) {
+      return exploreSectionFromArgs(args.addBaseParams(baseParams ?? {}));
+    }).toList();
   }
 
-  void changePage(ExplorePage page) {
-    update(
-      title: page.title,
-      sections: page.sections,
-    );
+  void changePage(ExplorePageArguments args) {
+    _navigationService.navigateTo(Routes.explore, arguments: args);
   }
 
-  void update(
-      {List<ExploreSection>? sections,
-      String? title,
-      bool saveHistory = true}) {
-    if (saveHistory) {
-      previousPages
-          .addLast(ExplorePage(sections: this.sections, title: this.title));
-    }
-    this.sections = sections ?? this.sections;
-    this.title = title ?? this.title;
-    notifyListeners();
-    init();
+  bool get canGoBack {
+    return _navigationService.canGoBack();
   }
-
-  bool get canBack => previousPages.length != 0;
 
   void back() {
-    if (previousPages.length == 0) {
-      return;
-    }
-    ExplorePage page = previousPages.last;
-    previousPages.removeLast();
-    update(sections: page.sections, title: page.title, saveHistory: false);
+    _navigationService.goBack();
   }
+
+  bool hasLinks() {
+    return sections.any((section) => section.args.link != null);
+  } 
 }
 
 //-- Explore Sections --//
@@ -348,21 +399,7 @@ class ExplorePageViewModel extends BaseModel with ExploreViewModelMixin {
 class ActionExploreSection extends ExploreSection<ListCauseAction> {
   final double tileHeight = 160;
 
-  ActionExploreSection({
-    required String title,
-    String? description,
-    ExplorePage? link,
-    Map<String, dynamic>? baseParams,
-    BaseExploreFilter? filter,
-    Color? backgroundColor,
-  }) : super(
-          title: title,
-          description: description,
-          link: link,
-          baseParams: baseParams,
-          filter: filter,
-          backgroundColor: backgroundColor,
-        );
+  ActionExploreSection(ExploreSectionArguments args) : super(args);
 
   Future<List<ListCauseAction>> fetchTiles(Map<String, dynamic> params) {
     return _causesService.getActions(params: queryParams);
@@ -374,21 +411,7 @@ class ActionExploreSection extends ExploreSection<ListCauseAction> {
 class LearningResourceExploreSection extends ExploreSection<LearningResource> {
   double tileHeight = 160;
 
-  LearningResourceExploreSection({
-    required String title,
-    String? description,
-    ExplorePage? link,
-    Map<String, dynamic>? baseParams,
-    BaseExploreFilter? filter,
-    Color? backgroundColor,
-  }) : super(
-          title: title,
-          description: description,
-          link: link,
-          baseParams: baseParams,
-          filter: filter,
-          backgroundColor: backgroundColor,
-        );
+  LearningResourceExploreSection(ExploreSectionArguments args) : super(args);
 
   Future<List<LearningResource>> fetchTiles(Map<String, dynamic> params) {
     return _causesService.getLearningResources(params: queryParams);
@@ -400,21 +423,7 @@ class LearningResourceExploreSection extends ExploreSection<LearningResource> {
 class CampaignExploreSection extends ExploreSection<ListCampaign> {
   double tileHeight = 300;
 
-  CampaignExploreSection({
-    required String title,
-    String? description,
-    ExplorePage? link,
-    Map<String, dynamic>? baseParams,
-    BaseExploreFilter? filter,
-    Color? backgroundColor,
-  }) : super(
-          title: title,
-          description: description,
-          link: link,
-          baseParams: baseParams,
-          filter: filter,
-          backgroundColor: backgroundColor,
-        );
+  CampaignExploreSection(ExploreSectionArguments args) : super(args);
 
   Future<List<ListCampaign>> fetchTiles(Map<String, dynamic> params) {
     return _causesService.getCampaigns(params: queryParams);
@@ -426,21 +435,7 @@ class CampaignExploreSection extends ExploreSection<ListCampaign> {
 class NewsExploreSection extends ExploreSection<Article> {
   double tileHeight = 330;
 
-  NewsExploreSection({
-    required String title,
-    String? description,
-    ExplorePage? link,
-    Map<String, dynamic>? baseParams,
-    BaseExploreFilter? filter,
-    Color? backgroundColor,
-  }) : super(
-          title: title,
-          description: description,
-          link: link,
-          baseParams: baseParams,
-          filter: filter,
-          backgroundColor: backgroundColor,
-        );
+  NewsExploreSection(ExploreSectionArguments args) : super(args);
 
   Future<List<Article>> fetchTiles(Map<String, dynamic> params) {
     NewsService _newsService = locator<NewsService>();

--- a/lib/viewmodels/home_model.dart
+++ b/lib/viewmodels/home_model.dart
@@ -20,22 +20,28 @@ class HomeViewModel extends BaseModel with ExploreViewModelMixin {
   final DialogService _dialogService = locator<DialogService>();
   final AuthenticationService _authService = locator<AuthenticationService>();
 
-  final ExploreSection myCampaigns = CampaignExploreSection(
+  final myCampaigns = exploreSectionFromArgs(ExploreSectionArguments(
     title: "My campaigns",
-  );
+    type: ExploreSectionType.Campaign,
+  ));
 
-  final ExploreSection suggestedCampaigns =
-      CampaignExploreSection(title: "Suggested campaigns", baseParams: {
-    "recommended": true,
-  });
+  final suggestedCampaigns = exploreSectionFromArgs(ExploreSectionArguments(
+    title: "Suggested campaigns",
+    baseParams: {
+      "recommended": true,
+    },
+    type: ExploreSectionType.Campaign,
+  ));
 
-  final ExploreSection myActions = ActionExploreSection(
+  final myActions = exploreSectionFromArgs(ExploreSectionArguments(
     title: "What can I do today?",
-  );
+    type: ExploreSectionType.Action,
+  ));
 
-  final ExploreSection inTheNews = NewsExploreSection(
+  final inTheNews = exploreSectionFromArgs(ExploreSectionArguments(
     title: "In the news",
-  );
+    type: ExploreSectionType.News,
+  ));
 
   HomeViewModel() {
     sections = [myCampaigns, suggestedCampaigns, myActions, inTheNews];

--- a/lib/viewmodels/startup_model.dart
+++ b/lib/viewmodels/startup_model.dart
@@ -40,6 +40,8 @@ class StartUpViewModel extends BaseModel {
 
     var currentUser = await _authenticationService.fetchUser();
 
-    _navigationService.navigateTo(currentUser != null ? Routes.home : Routes.intro, clearHistory: true);
+    _navigationService.navigateTo(
+        currentUser != null ? Routes.home : Routes.intro,
+        clearHistory: true);
   }
 }

--- a/lib/viewmodels/startup_model.dart
+++ b/lib/viewmodels/startup_model.dart
@@ -40,10 +40,6 @@ class StartUpViewModel extends BaseModel {
 
     var currentUser = await _authenticationService.fetchUser();
 
-    if (currentUser != null) {
-      _navigationService.navigateTo(Routes.home);
-    } else {
-      _navigationService.navigateTo(Routes.intro);
-    }
+    _navigationService.navigateTo(currentUser != null ? Routes.home : Routes.intro, clearHistory: true);
   }
 }

--- a/lib/viewmodels/tabs_view_model.dart
+++ b/lib/viewmodels/tabs_view_model.dart
@@ -3,16 +3,16 @@ import 'package:app/viewmodels/base_model.dart';
 enum TabPage { Home, Explore, Menu }
 
 class TabsViewModel extends BaseModel {
-    TabsViewModel(TabPage? initalPage) {
-        if (initalPage != null) {
-            this.currentPage = initalPage;
-        }
+  TabsViewModel(TabPage? initalPage) {
+    if (initalPage != null) {
+      this.currentPage = initalPage;
     }
+  }
 
-    TabPage currentPage = TabPage.Home;
+  TabPage currentPage = TabPage.Home;
 
-    void setPage(TabPage newPage) {
-        currentPage = newPage;
-        notifyListeners();
-    }
+  void setPage(TabPage newPage) {
+    currentPage = newPage;
+    notifyListeners();
+  }
 }

--- a/lib/viewmodels/tabs_view_model.dart
+++ b/lib/viewmodels/tabs_view_model.dart
@@ -1,0 +1,18 @@
+import 'package:app/viewmodels/base_model.dart';
+
+enum TabPage { Home, Explore, Menu }
+
+class TabsViewModel extends BaseModel {
+    TabsViewModel(TabPage? initalPage) {
+        if (initalPage != null) {
+            this.currentPage = initalPage;
+        }
+    }
+
+    TabPage currentPage = TabPage.Home;
+
+    void setPage(TabPage newPage) {
+        currentPage = newPage;
+        notifyListeners();
+    }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,7 +11,7 @@ description: A new Flutter project.
 # In iOS, build-name is used as CFBundleShortVersionString while build-number used as CFBundleVersion.
 # Read more about iOS versioning at
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
-version: 2.0.0-dev+43
+version: 2.0.0-dev+44
 
 environment:
   sdk: '>=2.15.0 <3.0.0'
@@ -75,7 +75,6 @@ dev_dependencies:
   flutter_redux_dev_tools: ^0.5.1
   dartdoc: ^6.0.0
   build_runner: ^2.1.4
-
 
 flutter_icons:
   ios: true


### PR DESCRIPTION
- Update explore page to use the regular navigator
- Update "See cause" link to navigate to cause page filtered by cause (note this is a bit broken as nested pages will not be filtered, we need to think more about this UX)
- Fixes for explore links
  - No white space when no links
  - No horizontal padding around list
- Add ViewModel to tabs page to handle current tab