### PR TITLE
Reorder search results to remove completed from home and shuffle results

### DIFF
--- a/lib/ui/views/home/home_viewmodel.dart
+++ b/lib/ui/views/home/home_viewmodel.dart
@@ -57,6 +57,7 @@ class HomeViewModel extends BaseViewModel {
             filter: CampaignSearchFilter(
               causeIds: causesFilter,
               recommended: true,
+              completed: false,
             ),
           )
           .then(
@@ -74,6 +75,7 @@ class HomeViewModel extends BaseViewModel {
             filter: CampaignSearchFilter(
               ofTheMonth: true,
               causeIds: causesFilter,
+              completed: false,
             ),
           )
           .then(
@@ -87,7 +89,10 @@ class HomeViewModel extends BaseViewModel {
                 .toList(),
           ),
       _searchService
-          .searchActions(filter: ActionSearchFilter(causeIds: causesFilter))
+          .searchActions(
+            filter:
+                ActionSearchFilter(causeIds: causesFilter, completed: false),
+          )
           .then(
             (value) => _myActions = value
                 .map(


### PR DESCRIPTION
# Description

Shuffle responses from meilisearch (using fixed random seed). Ive added a method to update this seed which I will use to change results order in a follow up.

Fixes https://tree.taiga.io/project/jelgar-now-u-1/us/228?backlog-status=2500907&no-milestone=1

# Checklist:

## Creator

- [x] The target branch is main
- [ ] I have updated the unreleased section of the change log
- [ ] I have reviewed the 'files changed' tab on github to ensure all changes are as expected
- [ ] I have added someone to review the pr

## Reviewer

- [ ] I have verified the above are all completed
- [ ] I have run the code locally to ensure it fufills the requirements of the issue
- [ ] I have reviewed the 'files changed' and commented on any sections which I think are not needed, incorrect or could be improved

## After pull

- [ ] If appropriate I have closed the issue/ moved the trello card
