### PR TITLE
Fix bug where back button shows after clicking "see cause"

### DIFF
--- a/lib/ui/views/explore/explore_page_view.dart
+++ b/lib/ui/views/explore/explore_page_view.dart
@@ -144,6 +144,7 @@ class _ExploreTabsState extends State<ExploreTabs>
         backgroundColor: Theme.of(context).colorScheme.background,
         elevation: 1,
         shadowColor: CustomColors.greyLight1,
+        automaticallyImplyLeading: false,
         flexibleSpace: Padding(
           padding: EdgeInsets.symmetric(
             horizontal: horizontalPadding,


### PR DESCRIPTION
# Description

Fix bug where back button was showing up over the search box on the explore page after clicking on "see cause" on the action details page.

Fixes #<issue_number> or taiga link

# Checklist:

## Creator

- [x] The target branch is main
- [ ] I have updated the unreleased section of the change log
- [ ] I have reviewed the 'files changed' tab on github to ensure all changes are as expected
- [ ] I have added someone to review the pr

## Reviewer

- [ ] I have verified the above are all completed
- [ ] I have run the code locally to ensure it fufills the requirements of the issue
- [ ] I have reviewed the 'files changed' and commented on any sections which I think are not needed, incorrect or could be improved

## After pull

- [ ] If appropriate I have closed the issue/ moved the trello card
