### PR TITLE
Split loading next page and initial search logic

### DIFF
--- a/lib/services/search_service.dart
+++ b/lib/services/search_service.dart
@@ -446,8 +446,8 @@ class SearchService {
   }
 
   Future<SearchResponse<LearningResource>> searchLearningResources({
-    required int offset,
     LearningResourceSearchFilter? filter,
+    int offset = 0,
   }) async {
     const limit = 20;
 

--- a/lib/ui/paging/paging_state.dart
+++ b/lib/ui/paging/paging_state.dart
@@ -9,7 +9,7 @@ sealed class PagingState<T> {
   bool canLoadMore() =>
       (this is InitialLoading || this is Data) && !hasReachedMax;
 
-  int itemsCount() => this is LoadingMore ? items.length + 1 : items.length;
+  int itemsCount() => items.length;
 }
 
 class InitialLoading extends PagingState {

--- a/lib/ui/views/explore/explore_page_view.dart
+++ b/lib/ui/views/explore/explore_page_view.dart
@@ -161,7 +161,7 @@ class _ExploreTabsState extends State<ExploreTabs>
                   _tabController?.animateTo(tab.index);
                 },
               ),
-        )
+            )
             .toList(),
       ),
     );

--- a/lib/ui/views/explore/explore_page_viewmodel.dart
+++ b/lib/ui/views/explore/explore_page_viewmodel.dart
@@ -80,7 +80,25 @@ class ExplorePageViewModel extends FormViewModel {
     ).wait;
   }
 
-  Future<void> searchActions() async {
+  ActionSearchFilter _getActionsFilter() {
+    return ActionSearchFilter(
+      causeIds: this.filterData.filterCauseIds.isEmpty
+          ? null
+          : filterData.filterCauseIds.toList(),
+      timeBrackets: this.filterData.filterTimeBrackets.isEmpty
+          ? null
+          : filterData.filterTimeBrackets.toList(),
+      types: this.filterData.filterActionTypes.isEmpty
+          ? null
+          : filterData.filterActionTypes.toList(),
+      completed: filterData.filterCompleted == true ? true : null,
+      recommended: filterData.filterRecommended == true ? true : null,
+      releasedSince: filterData.filterNew == true ? newSinceDate() : null,
+      query: searchBarValue,
+    );
+  }
+
+  Future<void> loadMoreActions() async {
     if (!actions.canLoadMore()) return;
 
     actions = LoadingMore(items: actions.items);
@@ -88,31 +106,49 @@ class ExplorePageViewModel extends FormViewModel {
     // Remove search fallback to use user causes
     SearchResponse<ListAction> response = await _searchService.searchActions(
       offset: actions.offset(),
-      filter: ActionSearchFilter(
-        causeIds: this.filterData.filterCauseIds.isEmpty
-            ? null
-            : filterData.filterCauseIds.toList(),
-        timeBrackets: this.filterData.filterTimeBrackets.isEmpty
-            ? null
-            : filterData.filterTimeBrackets.toList(),
-        types: this.filterData.filterActionTypes.isEmpty
-            ? null
-            : filterData.filterActionTypes.toList(),
-        completed: filterData.filterCompleted == true ? true : null,
-        recommended: filterData.filterRecommended == true ? true : null,
-        releasedSince: filterData.filterNew == true ? newSinceDate() : null,
-        query: searchBarValue,
-      ),
+      filter: _getActionsFilter(),
     );
 
     actions = Data(
       items: actions.items + response.items,
       hasReachedMax: response.hasReachedMax,
     );
+
     notifyListeners();
   }
 
-  Future<void> searchLearningResources() async {
+  Future<void> searchActions() async {
+    SearchResponse<ListAction> response = await _searchService.searchActions(
+      filter: _getActionsFilter(),
+    );
+
+    actions = Data(
+      items: response.items,
+      hasReachedMax: response.hasReachedMax,
+    );
+
+    notifyListeners();
+  }
+
+  LearningResourceSearchFilter _getLearningResourcesFilter() {
+    return LearningResourceSearchFilter(
+      causeIds: this.filterData.filterCauseIds.isEmpty
+          ? null
+          : filterData.filterCauseIds.toList(),
+      timeBrackets: this.filterData.filterTimeBrackets.isEmpty
+          ? null
+          : filterData.filterTimeBrackets.toList(),
+      // TODO Add learning resource types
+      // types:
+      //this.filterActionTypes.isEmpty ? null : filterActionTypes.toList(),
+      completed: filterData.filterCompleted == true ? true : null,
+      recommended: filterData.filterRecommended == true ? true : null,
+      releasedSince: filterData.filterNew == true ? newSinceDate() : null,
+      query: searchBarValue,
+    );
+  }
+
+  Future<void> loadMoreLearningResources() async {
     if (!learningResources.canLoadMore()) return;
 
     learningResources = LoadingMore(items: learningResources.items);
@@ -120,46 +156,51 @@ class ExplorePageViewModel extends FormViewModel {
     SearchResponse<LearningResource> response =
         await _searchService.searchLearningResources(
       offset: learningResources.offset(),
-      filter: LearningResourceSearchFilter(
-        causeIds: this.filterData.filterCauseIds.isEmpty
-            ? null
-            : filterData.filterCauseIds.toList(),
-        timeBrackets: this.filterData.filterTimeBrackets.isEmpty
-            ? null
-            : filterData.filterTimeBrackets.toList(),
-        // TODO Add learning resource types
-        // types:
-        //this.filterActionTypes.isEmpty ? null : filterActionTypes.toList(),
-        completed: filterData.filterCompleted == true ? true : null,
-        recommended: filterData.filterRecommended == true ? true : null,
-        releasedSince: filterData.filterNew == true ? newSinceDate() : null,
-        query: searchBarValue,
-      ),
+      filter: _getLearningResourcesFilter(),
     );
 
     learningResources = Data(
       items: learningResources.items + response.items,
       hasReachedMax: response.hasReachedMax,
     );
+
     notifyListeners();
   }
 
-  Future<void> searchCampaigns() async {
+  Future<void> searchLearningResources() async {
+    SearchResponse<LearningResource> response =
+        await _searchService.searchLearningResources(
+      filter: _getLearningResourcesFilter(),
+    );
+
+    learningResources = Data(
+      items: response.items,
+      hasReachedMax: response.hasReachedMax,
+    );
+
+    notifyListeners();
+  }
+
+  CampaignSearchFilter _getCampaignsFilter() {
+    return CampaignSearchFilter(
+      causeIds: this.filterData.filterCauseIds.isEmpty
+          ? null
+          : filterData.filterCauseIds.toList(),
+      completed: filterData.filterCompleted == true ? true : null,
+      recommended: filterData.filterRecommended == true ? true : null,
+      releasedSince: filterData.filterNew == true ? newSinceDate() : null,
+      query: searchBarValue,
+    );
+  }
+
+  Future<void> loadMoreCampaigns() async {
     if (!campaigns.canLoadMore()) return;
 
     campaigns = LoadingMore(items: campaigns.items);
 
     SearchResponse<ListCampaign> response =
         await _searchService.searchCampaigns(
-      filter: CampaignSearchFilter(
-        causeIds: this.filterData.filterCauseIds.isEmpty
-            ? null
-            : filterData.filterCauseIds.toList(),
-        completed: filterData.filterCompleted == true ? true : null,
-        recommended: filterData.filterRecommended == true ? true : null,
-        releasedSince: filterData.filterNew == true ? newSinceDate() : null,
-        query: searchBarValue,
-      ),
+      filter: _getCampaignsFilter(),
       offset: campaigns.offset(),
     );
 
@@ -167,23 +208,42 @@ class ExplorePageViewModel extends FormViewModel {
       items: campaigns.items + response.items,
       hasReachedMax: response.hasReachedMax,
     );
+
     notifyListeners();
   }
 
-  Future<void> searchNewsArticles() async {
+  Future<void> searchCampaigns() async {
+    SearchResponse<ListCampaign> response =
+        await _searchService.searchCampaigns(
+      filter: _getCampaignsFilter(),
+    );
+
+    campaigns = Data(
+      items: response.items,
+      hasReachedMax: response.hasReachedMax,
+    );
+
+    notifyListeners();
+  }
+
+  NewsArticleSearchFilter _getNewsArticlesFilter() {
+    return NewsArticleSearchFilter(
+      causeIds: this.filterData.filterCauseIds.isEmpty
+          ? null
+          : filterData.filterCauseIds.toList(),
+      releasedSince: filterData.filterNew == true ? newSinceDate() : null,
+      query: searchBarValue,
+    );
+  }
+
+  Future<void> loadMoreNewsArticles() async {
     if (!newsArticles.canLoadMore()) return;
 
     newsArticles = LoadingMore(items: newsArticles.items);
 
     SearchResponse<NewsArticle> response =
         await _searchService.searchNewsArticles(
-      filter: NewsArticleSearchFilter(
-        causeIds: this.filterData.filterCauseIds.isEmpty
-            ? null
-            : filterData.filterCauseIds.toList(),
-        releasedSince: filterData.filterNew == true ? newSinceDate() : null,
-        query: searchBarValue,
-      ),
+      filter: _getNewsArticlesFilter(),
       offset: newsArticles.offset(),
     );
 
@@ -191,6 +251,21 @@ class ExplorePageViewModel extends FormViewModel {
       items: newsArticles.items + response.items,
       hasReachedMax: response.hasReachedMax,
     );
+
+    notifyListeners();
+  }
+
+  Future<void> searchNewsArticles() async {
+    SearchResponse<NewsArticle> response =
+        await _searchService.searchNewsArticles(
+      filter: _getNewsArticlesFilter(),
+    );
+
+    newsArticles = Data(
+      items: response.items,
+      hasReachedMax: response.hasReachedMax,
+    );
+
     notifyListeners();
   }
 

--- a/lib/ui/views/explore/tabs/explore_action_tab.dart
+++ b/lib/ui/views/explore/tabs/explore_action_tab.dart
@@ -26,7 +26,7 @@ class ExploreActionTab extends StatelessWidget {
         CompletedFilter(viewModel: viewModel),
       ],
       onBottomReached: () => {
-        viewModel.searchActions(),
+        viewModel.loadMoreActions(),
       },
       pagingState: viewModel.actions,
       itemBuilder: (action) => Container(

--- a/lib/ui/views/explore/tabs/explore_campaign_tab.dart
+++ b/lib/ui/views/explore/tabs/explore_campaign_tab.dart
@@ -20,7 +20,7 @@ class ExploreCampaignTab extends StatelessWidget {
         CompletedFilter(viewModel: viewModel),
       ],
       onBottomReached: () => {
-        viewModel.searchCampaigns(),
+        viewModel.loadMoreCampaigns(),
       },
       pagingState: viewModel.campaigns,
       itemBuilder: (campaign) => Container(

--- a/lib/ui/views/explore/tabs/explore_learning_resource_tab.dart
+++ b/lib/ui/views/explore/tabs/explore_learning_resource_tab.dart
@@ -22,7 +22,7 @@ class ExploreLearningResourceTab extends StatelessWidget {
         CompletedFilter(viewModel: viewModel),
       ],
       onBottomReached: () => {
-        viewModel.searchLearningResources(),
+        viewModel.loadMoreLearningResources(),
       },
       pagingState: viewModel.learningResources,
       itemBuilder: (learningResource) => Container(

--- a/lib/ui/views/explore/tabs/explore_news_article_tab.dart
+++ b/lib/ui/views/explore/tabs/explore_news_article_tab.dart
@@ -16,6 +16,7 @@ class ExploreNewsArticleTab extends StatelessWidget {
       pagingState: viewModel.newsArticles,
       filterChips: [
         CausesFilter(viewModel: viewModel),
+        CompletedFilter(viewModel: viewModel),
       ],
       itemBuilder: (newsArticle) => Container(
         // TODO Create shared constant for these/ pull. from ExploreSectionArgs
@@ -29,7 +30,7 @@ class ExploreNewsArticleTab extends StatelessWidget {
         ),
       ),
       onBottomReached: () => {
-        viewModel.searchNewsArticles(),
+        viewModel.loadMoreNewsArticles(),
       },
     );
   }

--- a/lib/ui/views/explore/tabs/explore_tab.dart
+++ b/lib/ui/views/explore/tabs/explore_tab.dart
@@ -18,6 +18,15 @@ class ExploreTab<T> extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    if (pagingState is Data && pagingState.items.isEmpty) {
+      return ListView(
+        children: [
+          FiltersContainer(filterChips: filterChips),
+          const Center(child: Text('No results for search')),
+        ],
+      );
+    }
+
     return ListView.builder(
       itemCount: itemCount(),
       itemBuilder: (BuildContext context, int index) {
@@ -50,5 +59,5 @@ class ExploreTab<T> extends StatelessWidget {
 
   // +1 for the filter chips, +1 for the loading indicator if state is LoadingMore
   int itemCount() =>
-      pagingState.items.length + (pagingState is LoadingMore ? 1 : 2);
+      pagingState.items.length + (pagingState is LoadingMore ? 2 : 1);
 }


### PR DESCRIPTION
A few fixes for the pagination logic

1. Split loading new items and fetching more for a given search. This is so we can call search after changing a filter and get a fresh set of results (rather than appending filtered results to existing)
2. Fix the number of items expected in the list displaying search results