### PR TITLE
Update macOs version on GithubActions to 13

### DIFF
--- a/lib/services/navigation_service.dart
+++ b/lib/services/navigation_service.dart
@@ -156,7 +156,7 @@ class NavigationService {
     } else {
       if (extraOnConfirmFunction != null) extraOnConfirmFunction();
       await browser.open(
-        url: WebUri(url),
+        url: Uri.parse(url),
       );
     }
   }

--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -11,7 +11,6 @@ import firebase_core
 import firebase_crashlytics
 import firebase_messaging
 import firebase_remote_config
-import flutter_inappwebview_macos
 import flutter_secure_storage_macos
 import google_sign_in_ios
 import package_info_plus
@@ -28,7 +27,6 @@ func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   FLTFirebaseCrashlyticsPlugin.register(with: registry.registrar(forPlugin: "FLTFirebaseCrashlyticsPlugin"))
   FLTFirebaseMessagingPlugin.register(with: registry.registrar(forPlugin: "FLTFirebaseMessagingPlugin"))
   FLTFirebaseRemoteConfigPlugin.register(with: registry.registrar(forPlugin: "FLTFirebaseRemoteConfigPlugin"))
-  InAppWebViewFlutterPlugin.register(with: registry.registrar(forPlugin: "InAppWebViewFlutterPlugin"))
   FlutterSecureStoragePlugin.register(with: registry.registrar(forPlugin: "FlutterSecureStoragePlugin"))
   FLTGoogleSignInPlugin.register(with: registry.registrar(forPlugin: "FLTGoogleSignInPlugin"))
   FPPPackageInfoPlusPlugin.register(with: registry.registrar(forPlugin: "FPPPackageInfoPlusPlugin"))

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -473,58 +473,10 @@ packages:
     dependency: "direct main"
     description:
       name: flutter_inappwebview
-      sha256: "3e9a443a18ecef966fb930c3a76ca5ab6a7aafc0c7b5e14a4a850cf107b09959"
+      sha256: d198297060d116b94048301ee6749cd2e7d03c1f2689783f52d210a6b7aba350
       url: "https://pub.dev"
     source: hosted
-    version: "6.0.0"
-  flutter_inappwebview_android:
-    dependency: transitive
-    description:
-      name: flutter_inappwebview_android
-      sha256: d247f6ed417f1f8c364612fa05a2ecba7f775c8d0c044c1d3b9ee33a6515c421
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.0.13"
-  flutter_inappwebview_internal_annotations:
-    dependency: transitive
-    description:
-      name: flutter_inappwebview_internal_annotations
-      sha256: "5f80fd30e208ddded7dbbcd0d569e7995f9f63d45ea3f548d8dd4c0b473fb4c8"
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.1.1"
-  flutter_inappwebview_ios:
-    dependency: transitive
-    description:
-      name: flutter_inappwebview_ios
-      sha256: f363577208b97b10b319cd0c428555cd8493e88b468019a8c5635a0e4312bd0f
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.0.13"
-  flutter_inappwebview_macos:
-    dependency: transitive
-    description:
-      name: flutter_inappwebview_macos
-      sha256: b55b9e506c549ce88e26580351d2c71d54f4825901666bd6cfa4be9415bb2636
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.0.11"
-  flutter_inappwebview_platform_interface:
-    dependency: transitive
-    description:
-      name: flutter_inappwebview_platform_interface
-      sha256: "545fd4c25a07d2775f7d5af05a979b2cac4fbf79393b0a7f5d33ba39ba4f6187"
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.0.10"
-  flutter_inappwebview_web:
-    dependency: transitive
-    description:
-      name: flutter_inappwebview_web
-      sha256: d8c680abfb6fec71609a700199635d38a744df0febd5544c5a020bd73de8ee07
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.0.8"
+    version: "5.8.0"
   flutter_launcher_icons:
     dependency: "direct dev"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -45,7 +45,7 @@ dependencies:
   cupertino_icons: ^1.0.6
 
   flutter_secure_storage: ^9.0.0
-  flutter_inappwebview: ^6.0.0
+  flutter_inappwebview: ^5.8.0
   uni_links: ^0.5.1
   device_info: ^2.0.2
   


### PR DESCRIPTION
# Description

`macos-latests` is still using XCode version  = `14.1` and after WebView Update we need to use at least `14.3`: https://github.com/pichillilorenzo/flutter_inappwebview/issues/1697#i

# Checklist:

## Creator

- [ ] The target branch is main
- [ ] I have updated the unreleased section of the change log
- [ ] I have reviewed the 'files changed' tab on github to ensure all changes are as expected
- [ ] I have added someone to review the pr

## Reviewer

- [ ] I have verified the above are all completed
- [ ] I have run the code locally to ensure it fufills the requirements of the issue
- [ ] I have reviewed the 'files changed' and commented on any sections which I think are not needed, incorrect or could be improved

## After pull

- [ ] If appropriate I have closed the issue/ moved the trello card
