### PR TITLE
Fix double initalization during startup

### DIFF
--- a/lib/ui/views/startup/startup_view.dart
+++ b/lib/ui/views/startup/startup_view.dart
@@ -40,9 +40,4 @@ class StartupView extends StackedView<StartupViewModel> {
   viewModelBuilder(context) {
     return StartupViewModel();
   }
-
-  @override
-  onViewModelReady(StartupViewModel viewModel) {
-    viewModel.initialise();
-  }
 }


### PR DESCRIPTION
Startupview model implements Initalizable (via PostLoginViewModelMixin) which means Initalize method is called automatically. We were manually calling this method as well meaning it was called twice.

I've removed manually calling the method for now. Im a bit scared if we stop inheriting PostLoginViewModelMixin then this will break (which isn't super clear) but we can think about that later.

Sentry issues:
fixes APP-3H
fixes APP-T
