### PR TITLE
Show dialog when completing action but not logged in

### DIFF
--- a/lib/router.dart
+++ b/lib/router.dart
@@ -10,6 +10,31 @@ import 'package:url_launcher/url_launcher.dart';
 
 import 'router.gr.dart';
 
+const postLoginInitialRouteFallback = HomeRoute();
+
+extension AutoRouterXExtension on StackRouter {
+  Future<void> pushNamedRouteWithFallback({
+    required String? path,
+    required PageRouteInfo fallback,
+    bool clearHistroy = false,
+  }) async {
+    if (clearHistroy) {
+      removeWhere((_) => true);
+    }
+
+    if (path == null) {
+      await push(fallback);
+    } else {
+      await pushNamed(
+        path,
+        onFailure: (_) {
+          push(fallback);
+        },
+      );
+    }
+  }
+}
+
 @AutoRouterConfig(replaceInRouteName: 'View|Tab,Route')
 class AppRouter extends $AppRouter {
   AuthenticationBloc _authBloc;

--- a/lib/services/causes_service.dart
+++ b/lib/services/causes_service.dart
@@ -178,6 +178,12 @@ class CausesService {
   ///
   /// Marks a learning resource as completed
   Future completeLearningResource(LearningResource learningResource) async {
+    if (!_authService.isAuthenticated) {
+      _logger.warning(
+        'User is not logged in, skipping learning resource completion',
+      );
+      return;
+    }
     await (
       _causeServiceClient
           .getLearningResourcesApi()

--- a/lib/ui/dialogs/basic/basic_dialog.dart
+++ b/lib/ui/dialogs/basic/basic_dialog.dart
@@ -54,12 +54,12 @@ class BasicDialog extends StatelessWidget {
                   textAlign: TextAlign.center,
                   style: Theme.of(context).textTheme.headlineMedium,
                 ),
-                const SizedBox(height: 20),
+                const SizedBox(height: 15),
                 Padding(
                   padding: const EdgeInsets.all(5),
                   child: Text(
                     args.description,
-                    style: Theme.of(context).textTheme.bodySmall,
+                    style: Theme.of(context).textTheme.bodyLarge,
                     textAlign: TextAlign.center,
                   ),
                 ),
@@ -81,12 +81,12 @@ class BasicDialog extends StatelessWidget {
                   ]
                       .intersperse(
                         const SizedBox(
-                          height: 10,
+                          height: 15,
                         ),
                       )
                       .toList(),
                 ),
-                const SizedBox(height: 20),
+                const SizedBox(height: 10),
               ],
             ),
           ),

--- a/lib/ui/views/action_info/action_info_view.dart
+++ b/lib/ui/views/action_info/action_info_view.dart
@@ -9,9 +9,12 @@ import 'package:nowu/router.gr.dart';
 import 'package:nowu/services/causes_service.dart';
 import 'package:nowu/themes.dart';
 import 'package:nowu/ui/dialogs/action/action_completed_dialog.dart';
+import 'package:nowu/ui/dialogs/basic/basic_dialog.dart';
 import 'package:nowu/ui/views/action_info/bloc/action_info_bloc.dart';
 import 'package:nowu/ui/views/action_info/bloc/action_info_state.dart';
 import 'package:auto_route/auto_route.dart';
+import 'package:nowu/ui/views/authentication/bloc/authentication_bloc.dart';
+import 'package:nowu/ui/views/authentication/bloc/authentication_state.dart';
 import 'package:nowu/ui/views/explore/bloc/explore_filter_state.dart';
 
 const hPadding = CustomPaddingSize.small;
@@ -91,7 +94,7 @@ class _Body extends StatelessWidget {
                       label: const Text('Back'),
                       icon: const Icon(Icons.chevron_left),
                       onPressed: () {
-                        Navigator.pop(context);
+                        context.router.maybePop();
                       },
                     ),
                   ),
@@ -278,9 +281,47 @@ class _Body extends StatelessWidget {
                             alignment: Alignment.topCenter,
                             child: FilledButton(
                               child: const Text('Mark as done'),
-                              onPressed: () => context
-                                  .read<ActionInfoBloc>()
-                                  .markActionComplete(),
+                              onPressed: () {
+                                switch (
+                                    context.read<AuthenticationBloc>().state) {
+                                  case AuthenticationStateUnknown():
+                                  case AuthenticationStateUnauthenticated():
+                                    showDialog(
+                                      builder: (context) => BasicDialog(
+                                        BasicDialogArgs(
+                                          title: 'Login required',
+                                          description:
+                                              'Create a now-u account to track your progress and choose the causes you care about',
+                                          mainButtonArgs: BasicDialogButtonArgs(
+                                            text: 'Login',
+                                            onClick: () {
+                                              context.router.push(
+                                                LoginRoute(
+                                                  initialRoute: context
+                                                      .router.currentPath,
+                                                ),
+                                              );
+                                            },
+                                          ),
+                                          secondaryButtonArgs:
+                                              BasicDialogButtonArgs(
+                                            text: 'Cancel',
+                                            onClick: () {
+                                              context.router.maybePop();
+                                            },
+                                          ),
+                                        ),
+                                      ),
+                                      context: context,
+                                    );
+                                    break;
+                                  case AuthenticationStateAuthenticated():
+                                    context
+                                        .read<ActionInfoBloc>()
+                                        .markActionComplete();
+                                    break;
+                                }
+                              },
                               style: secondaryFilledButtonStyle,
                             ),
                           ),

--- a/lib/ui/views/intro/bloc/intro_bloc.dart
+++ b/lib/ui/views/intro/bloc/intro_bloc.dart
@@ -72,6 +72,6 @@ class IntroBloc extends Cubit<IntroState> {
 
   void _goToNextPage(BuildContext context) {
     _storageService.setIntroShown(true);
-    _appRouter.push(const LoginRoute());
+    _appRouter.push(LoginRoute());
   }
 }

--- a/lib/ui/views/login/bloc/login_bloc.dart
+++ b/lib/ui/views/login/bloc/login_bloc.dart
@@ -1,7 +1,5 @@
-import 'package:auto_route/auto_route.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:formz/formz.dart';
-import 'package:nowu/router.gr.dart';
 import 'package:nowu/services/auth.dart';
 
 import '../models/email.dart';
@@ -9,13 +7,10 @@ import './login_state.dart';
 
 class LoginBloc extends Cubit<LoginState> {
   AuthenticationService _authenticationService;
-  StackRouter _appRouter;
 
   LoginBloc({
     required AuthenticationService authenticationService,
-    required StackRouter appRouter,
   })  : _authenticationService = authenticationService,
-        _appRouter = appRouter,
         super(LoginState(email: Email.pure()));
 
   void onEmailChanged(String email) {
@@ -29,26 +24,35 @@ class LoginBloc extends Cubit<LoginState> {
   Future<void> onLoginWithEmail() async {
     final isValid = Formz.validate([state.email]);
     if (isValid == false) {
-      emit(state.copyWith(isValid: isValid, showValidation: true));
+      emit(state.copyWith(emailFormIsValid: isValid, showValidation: true));
       return;
     }
-    emit(state.copyWith(status: FormzSubmissionStatus.inProgress));
+    emit(state.copyWith(emailFormStatus: FormzSubmissionStatus.inProgress));
     try {
       await _authenticationService.sendSignInEmail(state.email.value);
-      emit(state.copyWith(status: FormzSubmissionStatus.success));
-      _appRouter.push(LoginEmailSentRoute(email: state.email.value));
+      emit(state.copyWith(emailFormStatus: FormzSubmissionStatus.success));
     } catch (e) {
-      emit(state.copyWith(status: FormzSubmissionStatus.failure));
+      emit(state.copyWith(emailFormStatus: FormzSubmissionStatus.failure));
     }
   }
 
   Future<void> onLoginWithOAuth(AuthProvider provider) async {
-    emit(state.copyWith(status: FormzSubmissionStatus.inProgress));
+    emit(
+      state.copyWith(socialMediaLoginStatus: SocialMediaLoginStatus.loading),
+    );
     try {
       await _authenticationService.signInWithOAuth(provider);
-      emit(state.copyWith(status: FormzSubmissionStatus.success));
+      emit(
+        state.copyWith(
+          socialMediaLoginStatus: SocialMediaLoginStatus.success,
+        ),
+      );
     } catch (_) {
-      emit(state.copyWith(status: FormzSubmissionStatus.failure));
+      emit(
+        state.copyWith(
+          socialMediaLoginStatus: SocialMediaLoginStatus.failure,
+        ),
+      );
     }
   }
 }

--- a/lib/ui/views/login/bloc/login_state.dart
+++ b/lib/ui/views/login/bloc/login_state.dart
@@ -5,11 +5,20 @@ import '../models/email.dart';
 
 part 'login_state.freezed.dart';
 
+enum SocialMediaLoginStatus {
+  initial,
+  loading,
+  failure,
+  success,
+}
+
 @freezed
 class LoginState with _$LoginState {
   factory LoginState({
-    @Default(FormzSubmissionStatus.initial) FormzSubmissionStatus status,
-    @Default(false) bool isValid,
+    @Default(SocialMediaLoginStatus.initial) socialMediaLoginStatus,
+    @Default(FormzSubmissionStatus.initial)
+    FormzSubmissionStatus emailFormStatus,
+    @Default(false) bool emailFormIsValid,
     @Default(false) bool showValidation,
     required Email email,
   }) = _LoginState;

--- a/lib/ui/views/login/components/login_auth_state_listener.dart
+++ b/lib/ui/views/login/components/login_auth_state_listener.dart
@@ -2,6 +2,7 @@ import 'package:auto_route/auto_route.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:logging/logging.dart';
+import 'package:nowu/router.dart';
 import 'package:nowu/router.gr.dart';
 import 'package:nowu/ui/views/authentication/bloc/authentication_bloc.dart';
 import 'package:nowu/ui/views/authentication/bloc/authentication_state.dart';
@@ -10,31 +11,45 @@ class LoginAuthStateListener extends StatelessWidget {
   final Logger _logger = Logger('LoginAuthStateListener');
 
   final Widget child;
+  final String? initialRoute;
 
-  LoginAuthStateListener({required this.child});
+  LoginAuthStateListener({
+    required this.child,
+    required this.initialRoute,
+  });
 
   @override
   Widget build(BuildContext context) {
     return BlocListener<AuthenticationBloc, AuthenticationState>(
       listener: (context, state) {
-        PageRouteInfo? _getNextRoute(AuthenticationState authState) {
-          switch (authState) {
-            case AuthenticationStateAuthenticated(:final user)
-                when !user.isInitialised:
-              return const ProfileSetupRoute();
-            case AuthenticationStateAuthenticated():
-              return TabsRoute(children: [const HomeRoute()]);
-            case AuthenticationStateUnauthenticated():
-            case AuthenticationStateUnknown():
-              return null;
-          }
-        }
+        switch (state) {
+          case AuthenticationStateAuthenticated(:final user)
+              when !user.isInitialised:
+            _logger.info(
+              'User authenticated but not yet initalized, pushing to profile setup',
+            );
+            context.router.replaceAll([const ProfileSetupRoute()]);
+            break;
 
-        final route = _getNextRoute(state);
-        _logger.info('Loging successful, next route: $route');
+          case AuthenticationStateAuthenticated():
+            _logger.info(
+              'User authenticated and initalized, pushing to initialRoute',
+            );
 
-        if (route != null) {
-          context.router.replaceAll([route]);
+            context.router.pushNamedRouteWithFallback(
+              path: initialRoute,
+              fallback: postLoginInitialRouteFallback,
+              // After login, we don't want people going back to mid way through login
+              clearHistroy: true,
+            );
+            break;
+
+          case AuthenticationStateUnauthenticated():
+          case AuthenticationStateUnknown():
+            _logger.info(
+              'User not authenticated not navigating yet',
+            );
+            break;
         }
       },
       child: child,

--- a/lib/ui/views/login/login_view.dart
+++ b/lib/ui/views/login/login_view.dart
@@ -20,10 +20,17 @@ import 'models/email.dart';
 
 @RoutePage()
 class LoginView extends StatelessWidget {
+  final String? initialRoute;
+
+  LoginView({
+    @QueryParam() this.initialRoute,
+  });
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(
       body: LoginAuthStateListener(
+        initialRoute: initialRoute,
         child: NotificationListener(
           onNotification: (OverscrollIndicatorNotification overscroll) {
             overscroll.disallowIndicator();
@@ -33,14 +40,26 @@ class LoginView extends StatelessWidget {
             create: (context) {
               return LoginBloc(
                 authenticationService: locator<AuthenticationService>(),
-                appRouter: AutoRouter.of(context),
               );
             },
-            child: ListView(
-              children: [
-                // TODO Fix clip scrolling under the status bar
-                LoginForm(),
-              ],
+            child: BlocListener<LoginBloc, LoginState>(
+              listener: (context, state) {
+                // Note we don't have to listen to social media state because thats handled in LoginAuthStateListener.
+                if (state.emailFormStatus == FormzSubmissionStatus.success) {
+                  context.router.push(
+                    LoginEmailSentRoute(
+                      email: state.email.value,
+                      initialRoute: initialRoute,
+                    ),
+                  );
+                }
+              },
+              child: ListView(
+                children: [
+                  // TODO Fix clip scrolling under the status bar
+                  LoginForm(initialRoute: initialRoute),
+                ],
+              ),
             ),
           ),
         ),
@@ -50,6 +69,12 @@ class LoginView extends StatelessWidget {
 }
 
 class LoginForm extends StatelessWidget {
+  final String? initialRoute;
+
+  LoginForm({
+    required this.initialRoute,
+  });
+
   @override
   Widget build(BuildContext context) {
     return Stack(
@@ -101,11 +126,11 @@ class LoginForm extends StatelessWidget {
               const SizedBox(height: 20),
               Container(
                 width: MediaQuery.of(context).size.width * 0.6,
-                child: const Column(
+                child: Column(
                   children: [
                     const _LoginButton(),
                     const SizedBox(height: 20),
-                    const _SkipButton(),
+                    _SkipButton(initialRoute: initialRoute),
                   ],
                 ),
               ),
@@ -181,7 +206,9 @@ class _EmailInput extends StatelessWidget {
 }
 
 class _SkipButton extends StatelessWidget {
-  const _SkipButton();
+  final String? initialRoute;
+
+  const _SkipButton({required this.initialRoute});
 
   @override
   Widget build(BuildContext context) {
@@ -191,9 +218,13 @@ class _SkipButton extends StatelessWidget {
         style: secondaryFilledButtonStyle,
         child: const Text('Skip'),
         onPressed: () async {
-          await context.router.replaceAll([
-            TabsRoute(children: [const HomeRoute()]),
-          ]);
+          await context.router.pushNamedRouteWithFallback(
+            path: initialRoute,
+            fallback: postLoginInitialRouteFallback,
+            // For the skip button we don't clear history so they can come back and
+            // try to login if they wish
+            clearHistroy: false,
+          );
         },
       ),
     );
@@ -212,7 +243,8 @@ class _LoginButton extends StatelessWidget {
           onPressed: () {
             context.read<LoginBloc>().onLoginWithEmail();
           },
-          loading: state.status == FormzSubmissionStatus.inProgress,
+          loading: state.emailFormIsValid == FormzSubmissionStatus.inProgress ||
+              state.socialMediaLoginStatus == SocialMediaLoginStatus.loading,
         );
       },
     );

--- a/lib/ui/views/login_code/login_code_view.dart
+++ b/lib/ui/views/login_code/login_code_view.dart
@@ -17,15 +17,18 @@ import 'model/login_code.dart';
 @RoutePage()
 class LoginCodeView extends StatelessWidget {
   final String email;
+  final String? initialRoute;
 
   const LoginCodeView({
     Key? key,
     @pathParam required this.email,
+    @pathParam this.initialRoute,
   }) : super(key: key);
 
   @override
   Widget build(BuildContext context) {
     return LoginAuthStateListener(
+      initialRoute: initialRoute,
       child: BlocProvider(
         create: (context) => LoginCodeBloc(
           email: email,

--- a/lib/ui/views/login_email_sent/login_email_sent_view.dart
+++ b/lib/ui/views/login_email_sent/login_email_sent_view.dart
@@ -12,16 +12,19 @@ import 'package:open_mail_app/open_mail_app.dart';
 class LoginEmailSentView extends StatelessWidget {
   final String email;
   final String? token;
+  final String? initialRoute;
 
   const LoginEmailSentView({
     Key? key,
     @pathParam required this.email,
     @pathParam this.token,
+    @pathParam this.initialRoute,
   }) : super(key: key);
 
   @override
   Widget build(BuildContext context) {
     return LoginAuthStateListener(
+      initialRoute: initialRoute,
       child: Theme(
         data: darkTheme,
         child: Builder(
@@ -98,8 +101,12 @@ class LoginEmailSentView extends StatelessWidget {
                       width: double.infinity,
                       child: FilledButton(
                         child: const Text('Use secret code'),
-                        onPressed: () =>
-                            context.router.push(LoginCodeRoute(email: email)),
+                        onPressed: () => context.router.push(
+                          LoginCodeRoute(
+                            email: email,
+                            initialRoute: initialRoute,
+                          ),
+                        ),
                       ),
                     ),
                   ),

--- a/lib/ui/views/more/more_view.dart
+++ b/lib/ui/views/more/more_view.dart
@@ -129,7 +129,7 @@ List<MenuItemData> getMenuItems(
           ),
         )
       else
-        const ActionMenuItem(
+        ActionMenuItem(
           title: 'Log in',
           // TODO Get icon
           icon: FontAwesomeIcons.solidUser,


### PR DESCRIPTION
# Description

Currently when the user is not logged in we show them buttons on the action info page which they can click to complete the action. If they click that button they get a 403. 
Instead this updates the button to show a dialog saying they need to login.
It also updates to login to take an "inititalRoute" parameter. This can be used to set the route which should be navigated to after login (or skip) is complete. 
This is used in the action flow so that the user is returned to the same action page after logging in

Fixes #291 

# Checklist:

## Creator

- [ ] The target branch is main
- [ ] I have updated the unreleased section of the change log
- [ ] I have reviewed the 'files changed' tab on github to ensure all changes are as expected
- [ ] I have added someone to review the pr

## Reviewer

- [ ] I have verified the above are all completed
- [ ] I have run the code locally to ensure it fufills the requirements of the issue
- [ ] I have reviewed the 'files changed' and commented on any sections which I think are not needed, incorrect or could be improved

## After pull

- [ ] If appropriate I have closed the issue/ moved the trello card
