### PR TITLE
Bug-314: Fix wrong title alignment on news articles

### DIFF
--- a/lib/assets/components/explore_tiles.dart
+++ b/lib/assets/components/explore_tiles.dart
@@ -1,19 +1,19 @@
+import 'package:auto_route/auto_route.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:font_awesome_flutter/font_awesome_flutter.dart';
 import 'package:intl/intl.dart';
-import 'package:auto_route/auto_route.dart';
 import 'package:nowu/assets/components/card.dart';
 import 'package:nowu/assets/components/cause_indicator.dart';
 import 'package:nowu/assets/components/custom_network_image.dart';
 import 'package:nowu/assets/components/explore_tiles/bloc/explore_learning_resource_tile_bloc.dart';
 import 'package:nowu/assets/components/explore_tiles/bloc/explore_learning_resource_tile_state.dart';
+import 'package:nowu/locator.dart';
 import 'package:nowu/models/article.dart';
 import 'package:nowu/router.dart';
 import 'package:nowu/router.gr.dart';
 import 'package:nowu/services/causes_service.dart';
 import 'package:nowu/utils/let.dart';
-import 'package:nowu/locator.dart';
 import 'package:url_launcher/url_launcher.dart';
 
 enum ExploreTileStyle {
@@ -315,6 +315,7 @@ class ExploreNewsArticleTile extends ExploreTile {
       child: InkWell(
         onTap: () => launchLink(article.link),
         child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
           children: [
             AspectRatio(
               aspectRatio: 1.8,


### PR DESCRIPTION
# Description

Fix wrong alignemnt of news article title

|  Before |  After |
|---|---|
| ![image](https://github.com/user-attachments/assets/be5e5328-0905-49e6-a7ed-bff6b544df2c) | ![image](https://github.com/user-attachments/assets/9526e47f-59db-43b1-9826-0bdd1d83feb1)  |

Fixes https://github.com/now-u/now-u-app/issues/314

# Checklist:

## Creator

- [ ] The target branch is main
- [ ] I have updated the unreleased section of the change log
- [ ] I have reviewed the 'files changed' tab on github to ensure all changes are as expected
- [ ] I have added someone to review the pr

## Reviewer

- [ ] I have verified the above are all completed
- [ ] I have run the code locally to ensure it fufills the requirements of the issue
- [ ] I have reviewed the 'files changed' and commented on any sections which I think are not needed, incorrect or could be improved

## After pull

- [ ] If appropriate I have closed the issue/ moved the trello card
