### PR TITLE
Fetch completion info from user progress bloc

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -20,6 +20,7 @@ import 'package:nowu/services/pushNotifications.dart';
 import 'package:nowu/services/storage.dart';
 import 'package:nowu/services/user_service.dart';
 import 'package:nowu/themes.dart';
+import 'package:nowu/ui/components/user_progress/bloc/user_progress_bloc.dart';
 import 'package:nowu/ui/views/authentication/bloc/authentication_bloc.dart';
 import 'package:nowu/ui/views/authentication/bloc/authentication_state.dart';
 import 'package:nowu/ui/views/causes/bloc/causes_bloc.dart';
@@ -125,6 +126,11 @@ class App extends StatelessWidget {
                   locator<InternalNotificationService>(),
             )..fetchInternalNotifactions();
           },
+        ),
+        BlocProvider(
+          create: (_) => UserProgressBloc(
+            causesService: locator<CausesService>(),
+          )..fetchUserState(),
         ),
       ],
       child: Builder(

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -130,7 +130,7 @@ class App extends StatelessWidget {
         BlocProvider(
           create: (_) => UserProgressBloc(
             causesService: locator<CausesService>(),
-          )..fetchUserState(),
+          )..init(),
         ),
       ],
       child: Builder(

--- a/lib/models/action.dart
+++ b/lib/models/action.dart
@@ -3,7 +3,6 @@ import 'package:causeApiClient/causeApiClient.dart' as Api;
 import 'package:built_collection/built_collection.dart';
 import 'package:nowu/assets/icons/customIcons.dart';
 import 'package:flutter/material.dart' hide Action;
-import 'package:nowu/models/user.dart';
 import 'package:nowu/models/cause.dart';
 import 'package:nowu/models/exploreable.dart';
 import 'package:nowu/models/time.dart';
@@ -114,16 +113,11 @@ class ListAction implements Explorable {
   DateTime releaseAt;
   DateTime createdAt;
   int time;
-  bool isCompleted;
 
   DateTime get releaseTime => releaseAt;
 
   bool get isNew => isNewDate(releaseTime);
   String get timeText => getTimeText(time);
-
-  bool isCompletedByUser(Api.CausesUser user) {
-    return user.completedActionIds.contains(this.id);
-  }
 
   ListAction({
     required this.id,
@@ -133,7 +127,6 @@ class ListAction implements Explorable {
     required this.time,
     required this.cause,
     required this.type,
-    required this.isCompleted,
   });
 
   ListAction.fromApiData({
@@ -144,14 +137,11 @@ class ListAction implements Explorable {
     required this.time,
     required BuiltList<Api.Cause> causes,
     required Api.ActionTypeEnum actionType,
-    required CausesUser? userInfo,
-  })  : cause = Cause.fromApiModel(causes[0], userInfo),
-        isCompleted = userInfo?.completedActionIds.contains(id) ?? false,
+  })  : cause = Cause.fromApiModel(causes[0]),
         type = getActionTypeFromSubtype(actionType);
 
   factory ListAction.fromApiModel(
     Api.ListAction apiModel,
-    CausesUser? userInfo,
   ) {
     return ListAction.fromApiData(
       id: apiModel.id,
@@ -161,7 +151,6 @@ class ListAction implements Explorable {
       time: apiModel.time,
       causes: apiModel.causes,
       actionType: apiModel.actionType,
-      userInfo: userInfo,
     );
   }
 }
@@ -182,12 +171,10 @@ class Action extends ListAction {
     required super.time,
     required super.cause,
     required super.type,
-    required super.isCompleted,
   });
 
   Action.fromApiModel(
     Api.Action apiModel,
-    CausesUser? userInfo,
   )   : whatDescription = apiModel.whatDescription,
         whyDescription = apiModel.whyDescription,
         link = Uri.parse(apiModel.link),
@@ -199,6 +186,5 @@ class Action extends ListAction {
           time: apiModel.time,
           causes: apiModel.causes,
           actionType: apiModel.actionType,
-          userInfo: userInfo,
         );
 }

--- a/lib/models/action.dart
+++ b/lib/models/action.dart
@@ -137,7 +137,7 @@ class ListAction implements Explorable {
     required this.time,
     required BuiltList<Api.Cause> causes,
     required Api.ActionTypeEnum actionType,
-  })  : cause = Cause.fromApiModel(causes[0]),
+  })  : cause = Cause.fromApiModel(causes.first),
         type = getActionTypeFromSubtype(actionType);
 
   factory ListAction.fromApiModel(

--- a/lib/models/campaign.dart
+++ b/lib/models/campaign.dart
@@ -1,7 +1,6 @@
 import 'package:built_collection/built_collection.dart';
 import 'package:causeApiClient/causeApiClient.dart' as Api;
 import 'package:nowu/models/exploreable.dart';
-import 'package:nowu/models/user.dart';
 import 'package:nowu/services/causes_service.dart';
 
 class Campaign extends ListCampaign {
@@ -14,36 +13,22 @@ class Campaign extends ListCampaign {
     required super.title,
     required super.headerImage,
     required super.cause,
-    required super.isCompleted,
     required this.description,
     required this.actions,
     required this.learningResources,
   });
 
-  Campaign.fromApiModel(Api.Campaign apiModel, CausesUser? causesUser)
+  Campaign.fromApiModel(Api.Campaign apiModel)
       : description = apiModel.description.replaceAll('\\n', '\n\n'),
-        actions = apiModel.actions
-            .map(
-              (action) => ListAction.fromApiModel(
-                action,
-                causesUser,
-              ),
-            )
-            .toList(),
+        actions = apiModel.actions.map(ListAction.fromApiModel).toList(),
         learningResources = apiModel.learningResources
-            .map(
-              (learningResource) => LearningResource.fromApiModel(
-                learningResource,
-                causesUser,
-              ),
-            )
+            .map(LearningResource.fromApiModel)
             .toList(),
         super.fromApiData(
           id: apiModel.id,
           title: apiModel.title,
           headerImage: apiModel.headerImage,
           causes: apiModel.causes,
-          causesUser: causesUser,
         );
 
   Future<String> getShareText() async {
@@ -63,14 +48,12 @@ class ListCampaign implements Explorable {
   String title;
   Api.Image headerImage;
   Cause cause;
-  bool isCompleted;
 
   ListCampaign({
     required this.id,
     required this.title,
     required this.headerImage,
     required this.cause,
-    required this.isCompleted,
   });
 
   ListCampaign.fromApiData({
@@ -78,16 +61,13 @@ class ListCampaign implements Explorable {
     required this.title,
     required this.headerImage,
     required BuiltList<Api.Cause> causes,
-    required CausesUser? causesUser,
-  })  : cause = Cause.fromApiModel(causes[0], causesUser),
-        isCompleted = causesUser?.completedCampaignIds.contains(id) ?? false;
+  }) : cause = Cause.fromApiModel(causes[0]);
 
-  ListCampaign.fromApiModel(Api.ListCampaign apiModel, CausesUser? causesUser)
+  ListCampaign.fromApiModel(Api.ListCampaign apiModel)
       : this.fromApiData(
           id: apiModel.id,
           title: apiModel.title,
           headerImage: apiModel.headerImage,
           causes: apiModel.causes,
-          causesUser: causesUser,
         );
 }

--- a/lib/models/campaign.dart
+++ b/lib/models/campaign.dart
@@ -61,7 +61,7 @@ class ListCampaign implements Explorable {
     required this.title,
     required this.headerImage,
     required BuiltList<Api.Cause> causes,
-  }) : cause = Cause.fromApiModel(causes[0]);
+  }) : cause = Cause.fromApiModel(causes.first);
 
   ListCampaign.fromApiModel(Api.ListCampaign apiModel)
       : this.fromApiData(

--- a/lib/models/cause.dart
+++ b/lib/models/cause.dart
@@ -4,7 +4,6 @@ import 'package:font_awesome_flutter/font_awesome_flutter.dart';
 import 'package:nowu/assets/icons/customIcons.dart';
 import 'package:flutter/widgets.dart';
 import 'package:causeApiClient/src/model/icon_enum.dart';
-import 'package:nowu/models/user.dart';
 import 'package:nowu/models/exploreable.dart';
 
 export 'package:causeApiClient/causeApiClient.dart' show Cause, IconEnum;
@@ -18,7 +17,6 @@ class Cause implements Explorable {
   final String title;
   final String description;
   final IconData icon;
-  final bool isSelected;
   final Api.Image headerImage;
 
   Cause({
@@ -26,17 +24,15 @@ class Cause implements Explorable {
     required this.title,
     required this.description,
     required this.icon,
-    required this.isSelected,
     required this.headerImage,
   });
 
-  Cause.fromApiModel(Api.Cause apiModel, CausesUser? userInfo)
+  Cause.fromApiModel(Api.Cause apiModel)
       : id = apiModel.id,
         title = apiModel.title,
         description = apiModel.description,
         headerImage = apiModel.headerImage,
-        icon = _iconFromApiModelIcon(apiModel.icon),
-        isSelected = userInfo?.selectedCausesIds.contains(apiModel.id) ?? false;
+        icon = _iconFromApiModelIcon(apiModel.icon);
 }
 
 IconData _iconFromApiModelIcon(IconEnum icon) {

--- a/lib/models/learning.dart
+++ b/lib/models/learning.dart
@@ -2,7 +2,6 @@ import 'package:causeApiClient/causeApiClient.dart' as Api;
 import 'package:flutter/material.dart';
 import 'package:font_awesome_flutter/font_awesome_flutter.dart';
 import 'package:nowu/assets/icons/customIcons.dart';
-import 'package:nowu/models/user.dart';
 import 'package:nowu/models/cause.dart';
 import 'package:nowu/models/exploreable.dart';
 import 'package:nowu/models/time.dart';
@@ -66,7 +65,6 @@ class LearningResource extends Explorable {
   int time;
   DateTime createdAt;
   Uri link;
-  bool isCompleted;
 
   LearningResource({
     required this.id,
@@ -76,22 +74,17 @@ class LearningResource extends Explorable {
     required this.type,
     required this.time,
     required this.createdAt,
-    required this.isCompleted,
   });
 
   LearningResource.fromApiModel(
     Api.LearningResource apiModel,
-    CausesUser? userInfo,
   )   : id = apiModel.id,
         title = apiModel.title,
         link = Uri.parse(apiModel.link),
-        cause = Cause.fromApiModel(apiModel.causes[0], userInfo),
+        cause = Cause.fromApiModel(apiModel.causes[0]),
         type = getResourceTypeFromEnum(apiModel.learningResourceType),
         time = apiModel.time,
-        createdAt = apiModel.createdAt,
-        isCompleted =
-            userInfo?.completedLearningResourceIds.contains(apiModel.id) ??
-                false;
+        createdAt = apiModel.createdAt;
 
   String get timeText => timeBrackets.firstWhere((b) => b.maxTime > time).text;
 

--- a/lib/models/learning.dart
+++ b/lib/models/learning.dart
@@ -81,7 +81,7 @@ class LearningResource extends Explorable {
   )   : id = apiModel.id,
         title = apiModel.title,
         link = Uri.parse(apiModel.link),
-        cause = Cause.fromApiModel(apiModel.causes[0]),
+        cause = Cause.fromApiModel(apiModel.causes.first),
         type = getResourceTypeFromEnum(apiModel.learningResourceType),
         time = apiModel.time,
         createdAt = apiModel.createdAt;

--- a/lib/services/causes_service.dart
+++ b/lib/services/causes_service.dart
@@ -50,19 +50,9 @@ class CausesService {
 
   Future<List<Cause>?> _fetchCauses() async {
     _logger.info('Fetching causes from the service');
-    final (response, userInfo) = await (
-      _causeServiceClient.getCausesApi().causesList(),
-      getUserInfo(),
-    ).wait;
+    final response = await _causeServiceClient.getCausesApi().causesList();
 
-    final causes = response.data
-        ?.map(
-          (model) => Cause.fromApiModel(
-            model,
-            userInfo,
-          ),
-        )
-        .toList();
+    final causes = response.data?.map(Cause.fromApiModel).toList();
 
     _logger.info('Got causes, ${_causesStore.value}');
 
@@ -93,11 +83,9 @@ class CausesService {
   /// Input Action id
   /// Returns the Action with that id
   Future<Campaign> getCampaign(int id) async {
-    final (response, userInfo) = await (
-      _causeServiceClient.getCampaignsApi().campaignsRetrieve(id: id),
-      getUserInfo(),
-    ).wait;
-    return Campaign.fromApiModel(response.data!, userInfo);
+    final response =
+        await _causeServiceClient.getCampaignsApi().campaignsRetrieve(id: id);
+    return Campaign.fromApiModel(response.data!);
   }
 
   /// Get an action by id
@@ -106,14 +94,9 @@ class CausesService {
   /// Return a List of ListActions
   Future<Action> getAction(int id) async {
     _logger.info('Getting action id=$id');
-    final (response, userInfo) = await (
-      _causeServiceClient.getActionsApi().actionsRetrieve(id: id),
-      getUserInfo(),
-    ).wait;
-    return Action.fromApiModel(
-      response.data!,
-      userInfo,
-    );
+    final response =
+        await _causeServiceClient.getActionsApi().actionsRetrieve(id: id);
+    return Action.fromApiModel(response.data!);
   }
 
   /// Set user's selected causes

--- a/lib/services/search_service.dart
+++ b/lib/services/search_service.dart
@@ -366,14 +366,7 @@ class SearchService {
       hits,
       specifiedType: const FullType(BuiltList, [FullType(Api.ListAction)]),
     ) as BuiltList<Api.ListAction>;
-    return results
-        .map(
-          (action) => ListAction.fromApiModel(
-            action,
-            userInfo,
-          ),
-        )
-        .toList();
+    return results.map(ListAction.fromApiModel).toList();
   }
 
   List<LearningResource> _searchHitsToLearningResources(
@@ -385,14 +378,7 @@ class SearchService {
       specifiedType:
           const FullType(BuiltList, [FullType(Api.LearningResource)]),
     ) as BuiltList<Api.LearningResource>;
-    return results
-        .map(
-          (learningResource) => LearningResource.fromApiModel(
-            learningResource,
-            userInfo,
-          ),
-        )
-        .toList();
+    return results.map(LearningResource.fromApiModel).toList();
   }
 
   List<ListCampaign> _searchHitsToCampaign(
@@ -404,14 +390,7 @@ class SearchService {
       specifiedType: const FullType(BuiltList, [FullType(Api.ListCampaign)]),
     ) as BuiltList<Api.ListCampaign>;
 
-    return results
-        .map(
-          (campaign) => ListCampaign.fromApiModel(
-            campaign,
-            userInfo,
-          ),
-        )
-        .toList();
+    return results.map(ListCampaign.fromApiModel).toList();
   }
 
   List<NewsArticle> _searchHitsToNewsArticles(
@@ -422,7 +401,7 @@ class SearchService {
       hits,
       specifiedType: const FullType(BuiltList, [FullType(Api.NewsArticle)]),
     ) as BuiltList<Api.NewsArticle>;
-    return results.map((e) => NewsArticle.fromApiModel(e)).toList();
+    return results.map(NewsArticle.fromApiModel).toList();
   }
 
   Future<List<T>> _searchIndex<T>(

--- a/lib/ui/common/cause_tile.dart
+++ b/lib/ui/common/cause_tile.dart
@@ -1,21 +1,23 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:font_awesome_flutter/font_awesome_flutter.dart';
 import 'package:nowu/assets/constants.dart';
 import 'package:nowu/models/cause.dart';
+import 'package:nowu/ui/components/user_progress/bloc/user_progress_bloc.dart';
+import 'package:nowu/ui/components/user_progress/bloc/user_progress_state.dart';
 import 'package:nowu/ui/dialogs/cause/cause_dialog.dart';
 
 class CauseTile extends StatelessWidget {
   final Cause cause;
-  final bool isSelected;
   final IconData icon;
   final VoidCallback onSelect;
+  final bool? isSelectedOverride;
 
   CauseTile({
     required this.cause,
     required this.onSelect,
-    bool? isSelectedOverride,
-  })  : this.isSelected = isSelectedOverride ?? cause.isSelected,
-        this.icon = cause.icon;
+    bool? this.isSelectedOverride,
+  }) : this.icon = cause.icon;
 
   void openInfoDialog(BuildContext context) {
     showDialog(
@@ -33,74 +35,91 @@ class CauseTile extends StatelessWidget {
   Widget build(BuildContext context) {
     return GestureDetector(
       onTap: onSelect,
-      child: Container(
-        decoration: BoxDecoration(
-          color: isSelected ? const Color(0XFFFFF3E5) : Colors.white,
-          borderRadius: const BorderRadius.all(Radius.circular(10)),
-          border: isSelected
-              ? Border.all(width: 3, color: Theme.of(context).primaryColor)
-              : Border.all(width: 3, color: Colors.transparent),
-          boxShadow: [
-            const BoxShadow(
-              color: Color.fromRGBO(0, 0, 0, 0.16),
-              offset: Offset(0, 8),
-              blurRadius: 6,
-            ),
-          ],
-        ),
-        child: Column(
-          children: [
-            Container(height: 18),
-            Expanded(
-              flex: 5,
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.center,
-                mainAxisAlignment: MainAxisAlignment.center,
-                children: [
-                  Padding(
-                    padding: const EdgeInsets.only(bottom: 4),
-                    child: Icon(
-                      icon,
-                      size: 48.0,
-                      color: isSelected
-                          ? Theme.of(context).primaryColor
-                          : CustomColors.black1,
-                    ),
-                  ),
-                  Center(
-                    child: Text(
-                      '${cause.title}',
-                      style: const TextStyle(
-                        fontSize: 18.0,
-                        fontWeight: FontWeight.bold,
-                        height: 1,
-                      ),
-                      textAlign: TextAlign.center,
-                    ),
-                  ),
-                ],
-              ),
-            ),
-            Row(
-              mainAxisAlignment: MainAxisAlignment.center,
-              children: [
-                MaterialButton(
-                  child: const Text(
-                    'Learn more',
-                    textAlign: TextAlign.center,
-                  ),
-                  onPressed: () => openInfoDialog(context),
-                  padding: const EdgeInsets.symmetric(horizontal: 0),
-                ),
-                IconButton(
-                  icon: const Icon(FontAwesomeIcons.circleQuestion, size: 14),
-                  onPressed: () => openInfoDialog(context),
+      child: BlocBuilder<UserProgressBloc, UserProgressState>(
+        buildWhen: (prev, curr) {
+          // If we are overriding selection then we don't care about state
+          if (isSelectedOverride != null) {
+            return false;
+          }
+
+          return prev.causeIsSelected(cause.id) !=
+              curr.causeIsSelected(cause.id);
+        },
+        builder: (context, state) {
+          final isSelected =
+              isSelectedOverride ?? state.causeIsSelected(cause.id);
+
+          return Container(
+            decoration: BoxDecoration(
+              color: isSelected ? const Color(0XFFFFF3E5) : Colors.white,
+              borderRadius: const BorderRadius.all(Radius.circular(10)),
+              border: isSelected
+                  ? Border.all(width: 3, color: Theme.of(context).primaryColor)
+                  : Border.all(width: 3, color: Colors.transparent),
+              boxShadow: [
+                const BoxShadow(
+                  color: Color.fromRGBO(0, 0, 0, 0.16),
+                  offset: Offset(0, 8),
+                  blurRadius: 6,
                 ),
               ],
             ),
-            const SizedBox(height: 1),
-          ],
-        ),
+            child: Column(
+              children: [
+                Container(height: 18),
+                Expanded(
+                  flex: 5,
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.center,
+                    mainAxisAlignment: MainAxisAlignment.center,
+                    children: [
+                      Padding(
+                        padding: const EdgeInsets.only(bottom: 4),
+                        child: Icon(
+                          icon,
+                          size: 48.0,
+                          color: isSelected
+                              ? Theme.of(context).primaryColor
+                              : CustomColors.black1,
+                        ),
+                      ),
+                      Center(
+                        child: Text(
+                          '${cause.title}',
+                          style: const TextStyle(
+                            fontSize: 18.0,
+                            fontWeight: FontWeight.bold,
+                            height: 1,
+                          ),
+                          textAlign: TextAlign.center,
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+                Row(
+                  mainAxisAlignment: MainAxisAlignment.center,
+                  children: [
+                    MaterialButton(
+                      child: const Text(
+                        'Learn more',
+                        textAlign: TextAlign.center,
+                      ),
+                      onPressed: () => openInfoDialog(context),
+                      padding: const EdgeInsets.symmetric(horizontal: 0),
+                    ),
+                    IconButton(
+                      icon:
+                          const Icon(FontAwesomeIcons.circleQuestion, size: 14),
+                      onPressed: () => openInfoDialog(context),
+                    ),
+                  ],
+                ),
+                const SizedBox(height: 1),
+              ],
+            ),
+          );
+        },
       ),
     );
   }

--- a/lib/ui/components/user_progress/bloc/user_progress_bloc.dart
+++ b/lib/ui/components/user_progress/bloc/user_progress_bloc.dart
@@ -19,7 +19,7 @@ class UserProgressBloc extends Cubit<UserProgressState> {
     });
   }
 
-  void fetchUserState() async {
+  void init() async {
     try {
       final userInfo = await _causesService.getUserInfo();
       if (userInfo == null) {

--- a/lib/ui/components/user_progress/bloc/user_progress_state.dart
+++ b/lib/ui/components/user_progress/bloc/user_progress_state.dart
@@ -5,9 +5,42 @@ part 'user_progress_state.freezed.dart';
 
 @freezed
 sealed class UserProgressState with _$UserProgressState {
-  const factory UserProgressState.loading() = Loading;
-  const factory UserProgressState.noUser() = NoUser;
+  const factory UserProgressState.loading() = UserProgressStateLoading;
+  const factory UserProgressState.noUser() = UserProgressStateNoUser;
   const factory UserProgressState.loaded({required CausesUser userInfo}) =
-      Loaded;
-  const factory UserProgressState.error(String message) = Error;
+      UserProgressStateLoaded;
+  const factory UserProgressState.error(String message) =
+      UserProgressStateError;
+}
+
+extension UserProgressStateExt on UserProgressState {
+  CausesUser? _getUserInfo() {
+    switch (this) {
+      case UserProgressStateLoading():
+      case UserProgressStateError():
+      case UserProgressStateNoUser():
+        return null;
+      case UserProgressStateLoaded(:final userInfo):
+        return userInfo;
+    }
+  }
+
+  bool learningResourceIsCompleted(int learningResourceId) {
+    return _getUserInfo()
+            ?.completedLearningResourceIds
+            .contains(learningResourceId) ??
+        false;
+  }
+
+  bool actionIsCompleted(int actionId) {
+    return _getUserInfo()?.completedActionIds.contains(actionId) ?? false;
+  }
+
+  bool campaignIsCompleted(int campaignId) {
+    return _getUserInfo()?.completedCampaignIds.contains(campaignId) ?? false;
+  }
+
+  bool causeIsSelected(int causeId) {
+    return _getUserInfo()?.selectedCausesIds.contains(causeId) ?? false;
+  }
 }

--- a/lib/ui/components/user_progress/user_progress.dart
+++ b/lib/ui/components/user_progress/user_progress.dart
@@ -1,7 +1,5 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:nowu/locator.dart';
-import 'package:nowu/services/causes_service.dart';
 
 import 'bloc/user_progress_state.dart';
 import 'bloc/user_progress_bloc.dart';
@@ -10,25 +8,21 @@ import 'bloc/user_progress_bloc.dart';
 class ProgressTile extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
-    return BlocProvider(
-      create: (_) => UserProgressBloc(causesService: locator<CausesService>())
-        ..fetchUserState(),
-      child: BlocBuilder<UserProgressBloc, UserProgressState>(
-        builder: (context, state) {
-          switch (state) {
-            case Loaded(:final userInfo):
-              return _ProgressTile(
-                campaignsScore: userInfo.completedCampaignIds.length,
-                actionsScore: userInfo.completedActionIds.length,
-                learningsScore: userInfo.completedLearningResourceIds.length,
-              );
-            case Loading():
-            case Error():
-            case NoUser():
-              return Container();
-          }
-        },
-      ),
+    return BlocBuilder<UserProgressBloc, UserProgressState>(
+      builder: (context, state) {
+        switch (state) {
+          case UserProgressStateLoaded(:final userInfo):
+            return _ProgressTile(
+              campaignsScore: userInfo.completedCampaignIds.length,
+              actionsScore: userInfo.completedActionIds.length,
+              learningsScore: userInfo.completedLearningResourceIds.length,
+            );
+          case UserProgressStateLoading():
+          case UserProgressStateError():
+          case UserProgressStateNoUser():
+            return Container();
+        }
+      },
     );
   }
 }

--- a/lib/ui/views/action_info/action_info_view.dart
+++ b/lib/ui/views/action_info/action_info_view.dart
@@ -7,6 +7,8 @@ import 'package:nowu/locator.dart';
 import 'package:nowu/router.gr.dart';
 import 'package:nowu/services/causes_service.dart';
 import 'package:nowu/themes.dart';
+import 'package:nowu/ui/components/user_progress/bloc/user_progress_bloc.dart';
+import 'package:nowu/ui/components/user_progress/bloc/user_progress_state.dart';
 import 'package:nowu/ui/dialogs/action/action_completed_dialog.dart';
 import 'package:nowu/ui/dialogs/basic/basic_dialog.dart';
 import 'package:nowu/ui/views/action_info/bloc/action_info_bloc.dart';
@@ -94,7 +96,7 @@ class _Body extends StatelessWidget {
                       label: const Text('Back'),
                       icon: const Icon(Icons.chevron_left),
                       onPressed: () {
-                        context.router.maybePop();
+                        context.router.popForced();
                       },
                     ),
                   ),
@@ -110,30 +112,38 @@ class _Body extends StatelessWidget {
                     child: Text(action.title),
                   ),
                 ),
-                Container(
-                  height: action.isCompleted ? null : 10,
-                  color: action.type.primaryColor,
-                  child: action.isCompleted
-                      ? Row(
-                          mainAxisSize: MainAxisSize.max,
-                          mainAxisAlignment: MainAxisAlignment.center,
-                          children: [
-                            const Icon(
-                              CustomIcons.ic_check,
-                              size: 15,
-                              color: Colors.white,
-                            ),
-                            const SizedBox(width: 7),
-                            Text(
-                              'Done',
-                              style: Theme.of(context)
-                                  .textTheme
-                                  .bodyLarge!
-                                  .copyWith(color: Colors.white),
-                            ),
-                          ],
-                        )
-                      : Container(),
+                BlocBuilder<UserProgressBloc, UserProgressState>(
+                  builder: (context, state) {
+                    final isComplete = state.actionIsCompleted(action.id);
+
+                    if (!isComplete) {
+                      return Container();
+                    }
+
+                    return Container(
+                      height: 10,
+                      color: action.type.primaryColor,
+                      child: Row(
+                        mainAxisSize: MainAxisSize.max,
+                        mainAxisAlignment: MainAxisAlignment.center,
+                        children: [
+                          const Icon(
+                            CustomIcons.ic_check,
+                            size: 15,
+                            color: Colors.white,
+                          ),
+                          const SizedBox(width: 7),
+                          Text(
+                            'Done',
+                            style: Theme.of(context)
+                                .textTheme
+                                .bodyLarge!
+                                .copyWith(color: Colors.white),
+                          ),
+                        ],
+                      ),
+                    );
+                  },
                 ),
                 Padding(
                   padding: const EdgeInsets.all(10),
@@ -243,159 +253,170 @@ class _Body extends StatelessWidget {
                   ),
                 ),
 
-                !action.isCompleted
-                    ?
-                    // If not completed show the then button
-                    Column(
-                        children: [
-                          //Dividor
-                          Padding(
-                            padding: const EdgeInsets.symmetric(
-                              horizontal: 10,
-                              vertical: 20,
-                            ),
-                            child: Container(
-                              width: double.infinity,
-                              color: const Color.fromRGBO(
-                                222,
-                                223,
-                                232,
-                                1,
-                              ),
-                              height: 1,
-                            ),
-                          ),
+                BlocBuilder<UserProgressBloc, UserProgressState>(
+                  builder: (context, state) {
+                    final isComplete = state.actionIsCompleted(action.id);
 
-                          // Then
-                          Center(
-                            child: Padding(
-                              padding: const EdgeInsets.all(15),
-                              child: Text(
-                                'Then',
-                                style:
-                                    Theme.of(context).textTheme.headlineMedium,
-                              ),
-                            ),
-                          ),
-                          Align(
-                            alignment: Alignment.topCenter,
-                            child: FilledButton(
-                              child: const Text('Mark as done'),
-                              onPressed: () {
-                                switch (
-                                    context.read<AuthenticationBloc>().state) {
-                                  case AuthenticationStateUnknown():
-                                  case AuthenticationStateUnauthenticated():
-                                    showDialog(
-                                      builder: (context) => BasicDialog(
-                                        BasicDialogArgs(
-                                          title: 'Login required',
-                                          description:
-                                              'Create a now-u account to track your progress and choose the causes you care about',
-                                          mainButtonArgs: BasicDialogButtonArgs(
-                                            text: 'Login',
-                                            onClick: () {
-                                              context.router.push(
-                                                LoginRoute(
-                                                  initialRoute: context
-                                                      .router.currentPath,
-                                                ),
-                                              );
-                                            },
-                                          ),
-                                          secondaryButtonArgs:
-                                              BasicDialogButtonArgs(
-                                            text: 'Cancel',
-                                            onClick: () {
-                                              context.router.maybePop();
-                                            },
-                                          ),
-                                        ),
-                                      ),
-                                      context: context,
-                                    );
-                                    break;
-                                  case AuthenticationStateAuthenticated():
-                                    context
-                                        .read<ActionInfoBloc>()
-                                        .markActionComplete();
-                                    break;
-                                }
-                              },
-                              style: secondaryFilledButtonStyle,
-                            ),
-                          ),
-                        ],
-                      )
-                    : // Otherwise show the youre great thing
-                    Padding(
-                        padding: const EdgeInsets.only(
-                          top: 20,
-                          bottom: 10,
-                        ),
-                        child: Container(
-                          color: action.type.secondaryColor,
-                          child: Padding(
-                            padding: const EdgeInsets.all(15.0),
-                            child: Column(
-                              children: [
-                                Text(
-                                  'Many small actions have a big impact',
-                                  textAlign: TextAlign.center,
-                                  style: Theme.of(context)
-                                      .textTheme
-                                      .headlineMedium,
+                    // TODO Make if statement
+                    return !isComplete
+                        ?
+                        // If not completed show the then button
+                        Column(
+                            children: [
+                              //Dividor
+                              Padding(
+                                padding: const EdgeInsets.symmetric(
+                                  horizontal: 10,
+                                  vertical: 20,
                                 ),
-                                const SizedBox(height: 10),
-                                RichText(
-                                  textAlign: TextAlign.center,
-                                  text: TextSpan(
-                                    style:
-                                        Theme.of(context).textTheme.bodyLarge,
-                                    children: [
-                                      const TextSpan(
-                                        text:
-                                            'Thank you for completing this action and contributing to this important cause!',
-                                      ),
-                                      // TODO What is happening to this?
-                                      // TextSpan(
-                                      //     text: _campaign!.title,
-                                      //     style: textStyleFrom(
-                                      //       Theme.of(context)
-                                      //           .textTheme
-                                      //           .bodyLarge,
-                                      //       color: Theme.of(context)
-                                      //           .buttonColor,
-                                      //     ),
-                                      //     recognizer:
-                                      //         TapGestureRecognizer()
-                                      //           ..onTap = () {
-                                      //             Navigator.of(context)
-                                      //                 .pushNamed(
-                                      //                     Routes
-                                      //                         .campaignInfo,
-                                      //                     arguments:
-                                      //                         _campaign!
-                                      //                             .id);
-                                      //           }),
-                                      // TextSpan(
-                                      //   text: " campaign.",
-                                      // ),
-                                    ],
+                                child: Container(
+                                  width: double.infinity,
+                                  color: const Color.fromRGBO(
+                                    222,
+                                    223,
+                                    232,
+                                    1,
+                                  ),
+                                  height: 1,
+                                ),
+                              ),
+
+                              // Then
+                              Center(
+                                child: Padding(
+                                  padding: const EdgeInsets.all(15),
+                                  child: Text(
+                                    'Then',
+                                    style: Theme.of(context)
+                                        .textTheme
+                                        .headlineMedium,
                                   ),
                                 ),
-                                const SizedBox(height: 15),
-                                Icon(
-                                  FontAwesomeIcons.calendar,
-                                  color: Theme.of(context).primaryColor,
-                                  size: 60,
+                              ),
+                              Align(
+                                alignment: Alignment.topCenter,
+                                child: FilledButton(
+                                  child: const Text('Mark as done'),
+                                  onPressed: () {
+                                    switch (context
+                                        .read<AuthenticationBloc>()
+                                        .state) {
+                                      case AuthenticationStateUnknown():
+                                      case AuthenticationStateUnauthenticated():
+                                        showDialog(
+                                          builder: (context) => BasicDialog(
+                                            BasicDialogArgs(
+                                              title: 'Login required',
+                                              description:
+                                                  'Create a now-u account to track your progress and choose the causes you care about',
+                                              mainButtonArgs:
+                                                  BasicDialogButtonArgs(
+                                                text: 'Login',
+                                                onClick: () {
+                                                  context.router.push(
+                                                    LoginRoute(
+                                                      initialRoute: context
+                                                          .router.currentPath,
+                                                    ),
+                                                  );
+                                                },
+                                              ),
+                                              secondaryButtonArgs:
+                                                  BasicDialogButtonArgs(
+                                                text: 'Cancel',
+                                                onClick: () {
+                                                  context.router.maybePop();
+                                                },
+                                              ),
+                                            ),
+                                          ),
+                                          context: context,
+                                        );
+                                        break;
+                                      case AuthenticationStateAuthenticated():
+                                        context
+                                            .read<ActionInfoBloc>()
+                                            .markActionComplete();
+                                        break;
+                                    }
+                                  },
+                                  style: secondaryFilledButtonStyle,
                                 ),
-                                const SizedBox(height: 20),
-                              ],
+                              ),
+                            ],
+                          )
+                        : // Otherwise show the youre great thing
+                        Padding(
+                            padding: const EdgeInsets.only(
+                              top: 20,
+                              bottom: 10,
                             ),
-                          ),
-                        ),
-                      ),
+                            child: Container(
+                              color: action.type.secondaryColor,
+                              child: Padding(
+                                padding: const EdgeInsets.all(15.0),
+                                child: Column(
+                                  children: [
+                                    Text(
+                                      'Many small actions have a big impact',
+                                      textAlign: TextAlign.center,
+                                      style: Theme.of(context)
+                                          .textTheme
+                                          .headlineMedium,
+                                    ),
+                                    const SizedBox(height: 10),
+                                    RichText(
+                                      textAlign: TextAlign.center,
+                                      text: TextSpan(
+                                        style: Theme.of(context)
+                                            .textTheme
+                                            .bodyLarge,
+                                        children: [
+                                          const TextSpan(
+                                            text:
+                                                'Thank you for completing this action and contributing to this important cause!',
+                                          ),
+                                          // TODO What is happening to this?
+                                          // TextSpan(
+                                          //     text: _campaign!.title,
+                                          //     style: textStyleFrom(
+                                          //       Theme.of(context)
+                                          //           .textTheme
+                                          //           .bodyLarge,
+                                          //       color: Theme.of(context)
+                                          //           .buttonColor,
+                                          //     ),
+                                          //     recognizer:
+                                          //         TapGestureRecognizer()
+                                          //           ..onTap = () {
+                                          //             Navigator.of(context)
+                                          //                 .pushNamed(
+                                          //                     Routes
+                                          //                         .campaignInfo,
+                                          //                     arguments:
+                                          //                         _campaign!
+                                          //                             .id);
+                                          //           }),
+                                          // TextSpan(
+                                          //   text: " campaign.",
+                                          // ),
+                                        ],
+                                      ),
+                                    ),
+                                    const SizedBox(height: 15),
+                                    Icon(
+                                      FontAwesomeIcons.calendar,
+                                      color: Theme.of(context).primaryColor,
+                                      size: 60,
+                                    ),
+                                    const SizedBox(height: 20),
+                                  ],
+                                ),
+                              ),
+                            ),
+                          );
+                  },
+                ),
 
                 const SizedBox(height: 30),
 
@@ -421,46 +442,55 @@ class _Body extends StatelessWidget {
                 ),
 
                 const SizedBox(height: 20),
-                Row(
-                  mainAxisAlignment: MainAxisAlignment.end,
-                  mainAxisSize: MainAxisSize.max,
-                  children: [
-                    action.isCompleted
-                        ? TextButton(
-                            child: const Text(
-                              'Mark as not done',
-                              style: TextStyle(fontSize: 14),
-                            ),
-                            onPressed: () {
-                              context
-                                  .read<ActionInfoBloc>()
-                                  .clearActionStatus();
-                            },
-                          )
-                        : Container(),
-                    const SizedBox(width: 10),
-                  ],
+                BlocBuilder<UserProgressBloc, UserProgressState>(
+                  builder: (context, state) {
+                    if (!state.actionIsCompleted(action.id)) {
+                      return Container();
+                    }
+
+                    return Row(
+                      mainAxisAlignment: MainAxisAlignment.end,
+                      mainAxisSize: MainAxisSize.max,
+                      children: [
+                        TextButton(
+                          child: const Text(
+                            'Mark as not done',
+                            style: TextStyle(fontSize: 14),
+                          ),
+                          onPressed: () {
+                            context.read<ActionInfoBloc>().clearActionStatus();
+                          },
+                        ),
+                        const SizedBox(width: 10),
+                      ],
+                    );
+                  },
                 ),
                 const SizedBox(height: 15),
-                !action.isCompleted
-                    ? Container()
-                    : Container(
-                        height: 65,
-                        color: const Color.fromRGBO(
-                          155,
-                          159,
-                          177,
-                          1,
-                        ),
-                        child: Center(
-                          child: Text(
-                            'You completed this action',
-                            style: Theme.of(context).textTheme.bodyLarge,
-                          ),
+                BlocBuilder<UserProgressBloc, UserProgressState>(
+                  builder: (context, state) {
+                    final isComplete = state.actionIsCompleted(action.id);
+
+                    if (!isComplete) {
+                      return const SizedBox(height: 70);
+                    }
+
+                    return Container(
+                      height: 65,
+                      color: const Color.fromRGBO(
+                        155,
+                        159,
+                        177,
+                        1,
+                      ),
+                      child: Center(
+                        child: Text(
+                          'You completed this action',
+                          style: Theme.of(context).textTheme.bodyLarge,
                         ),
                       ),
-                SizedBox(
-                  height: action.isCompleted ? 0 : 70,
+                    );
+                  },
                 ),
               ],
             ),

--- a/lib/ui/views/campaign_info/campaign_info_view.dart
+++ b/lib/ui/views/campaign_info/campaign_info_view.dart
@@ -8,6 +8,8 @@ import 'package:nowu/locator.dart';
 import 'package:nowu/router.gr.dart';
 import 'package:nowu/services/causes_service.dart';
 import 'package:auto_route/auto_route.dart';
+import 'package:nowu/ui/components/user_progress/bloc/user_progress_bloc.dart';
+import 'package:nowu/ui/components/user_progress/bloc/user_progress_state.dart';
 import 'package:nowu/ui/views/campaign_info/bloc/campaign_info_bloc.dart';
 import 'package:nowu/ui/views/campaign_info/bloc/campaign_info_state.dart';
 import 'package:tuple/tuple.dart';
@@ -119,14 +121,23 @@ class CampaignInfoView extends StatelessWidget {
         List<Tuple2<Widget, bool>> campaignResourceTiles = [];
         campaignResourceTiles.addAll(
           campaign.actions.map(
-            (action) => Tuple2(ExploreActionTile(action), action.isCompleted),
+            (action) => Tuple2(
+              ExploreActionTile(action),
+              context
+                  .read<UserProgressBloc>()
+                  .state
+                  .actionIsCompleted(action.id),
+            ),
           ),
         );
         campaignResourceTiles.addAll(
           campaign.learningResources.map(
             (learningResource) => Tuple2(
               ExploreLearningResourceTile(learningResource),
-              learningResource.isCompleted,
+              context
+                  .read<UserProgressBloc>()
+                  .state
+                  .learningResourceIsCompleted(learningResource.id),
             ),
           ),
         );

--- a/lib/ui/views/causes_selection/change_view/change_select_causes_view.dart
+++ b/lib/ui/views/causes_selection/change_view/change_select_causes_view.dart
@@ -4,8 +4,8 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:font_awesome_flutter/font_awesome_flutter.dart';
 import 'package:nowu/locator.dart';
 import 'package:nowu/services/causes_service.dart';
-import 'package:nowu/ui/views/causes/bloc/causes_bloc.dart';
-import 'package:nowu/ui/views/causes/bloc/causes_state.dart';
+import 'package:nowu/ui/components/user_progress/bloc/user_progress_bloc.dart';
+import 'package:nowu/ui/components/user_progress/bloc/user_progress_state.dart';
 import 'package:nowu/ui/views/causes_selection/bloc/causes_selection_bloc.dart';
 import 'package:nowu/ui/views/causes_selection/bloc/causes_selection_state.dart';
 import 'package:nowu/ui/views/causes_selection/components/causeTileGrid.dart';
@@ -21,17 +21,13 @@ class ChangeSelectCausesView extends StatelessWidget {
         Set<int> getInitialSelectedCausesIds() {
           // NOTE We don't want to use a bloc builder here as if the state changes we don't want to
           // reload and update the users selection which they are working on.
-          switch (context.read<CausesBloc>().state) {
-            case CausesStateLoaded(:final causes):
-              {
-                return causes
-                    .where((cause) => cause.isSelected)
-                    .map((cause) => cause.id)
-                    .toSet();
-              }
-            case CausesStateLoading():
-            case CausesStateError():
-              return Set();
+          switch (context.read<UserProgressBloc>().state) {
+            case UserProgressStateLoading():
+            case UserProgressStateError():
+            case UserProgressStateNoUser():
+              return {};
+            case UserProgressStateLoaded(:final userInfo):
+              return userInfo.selectedCausesIds;
           }
         }
 

--- a/lib/ui/views/explore/explore_page_view.dart
+++ b/lib/ui/views/explore/explore_page_view.dart
@@ -3,8 +3,8 @@ import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:nowu/assets/constants.dart';
 import 'package:nowu/router.gr.dart';
-import 'package:nowu/ui/views/causes/bloc/causes_bloc.dart';
-import 'package:nowu/ui/views/causes/bloc/causes_state.dart';
+import 'package:nowu/ui/components/user_progress/bloc/user_progress_bloc.dart';
+import 'package:nowu/ui/components/user_progress/bloc/user_progress_state.dart';
 import 'package:nowu/ui/views/explore/bloc/explore_filter_bloc.dart';
 import 'package:nowu/ui/views/explore/bloc/explore_filter_state.dart';
 
@@ -21,15 +21,13 @@ class ExploreView extends StatelessWidget {
     BuildContext context,
   ) {
     Set<int> getSelectedCausesIds() {
-      switch (context.read<CausesBloc>().state) {
-        case CausesStateLoading():
-        case CausesStateError():
+      switch (context.read<UserProgressBloc>().state) {
+        case UserProgressStateLoading():
+        case UserProgressStateNoUser():
+        case UserProgressStateError():
           return {};
-        case CausesStateLoaded(:final causes):
-          return causes
-              .where((cause) => cause.isSelected)
-              .map((cause) => cause.id)
-              .toSet();
+        case UserProgressStateLoaded(:final userInfo):
+          return userInfo.selectedCausesIds;
       }
     }
 

--- a/test/factories/action_factory.dart
+++ b/test/factories/action_factory.dart
@@ -14,7 +14,6 @@ class ListActionFactory extends ModelFactory<ListAction> {
       time: faker.randomGenerator.integer(10),
       releaseAt: faker.date.dateTime(),
       createdAt: faker.date.dateTime(),
-      isCompleted: true,
     );
   }
 }
@@ -32,7 +31,6 @@ class ActionFactory extends ModelFactory<Action> {
       createdAt: faker.date.dateTime(),
       whatDescription: faker.lorem.words(100).join(' '),
       whyDescription: faker.lorem.words(100).join(' '),
-      isCompleted: faker.randomGenerator.boolean(),
       link: Uri.parse(faker.internet.uri('https')),
     );
   }

--- a/test/factories/campaign_factory.dart
+++ b/test/factories/campaign_factory.dart
@@ -14,7 +14,6 @@ class ListCampaignFactory extends ModelFactory<ListCampaign> {
       title: faker.lorem.sentence(),
       headerImage: ImageFactory().generate(),
       cause: CauseFactory().generate(),
-      isCompleted: true,
     );
   }
 }
@@ -30,7 +29,6 @@ class CampaignFactory extends ModelFactory<Campaign> {
       actions: ListActionFactory().generateList(length: 2),
       learningResources: LearningResourceFactory().generateList(length: 2),
       description: faker.lorem.words(100).join(' '),
-      isCompleted: true,
     );
   }
 }

--- a/test/factories/cause_factory.dart
+++ b/test/factories/cause_factory.dart
@@ -11,7 +11,6 @@ class CauseFactory extends ModelFactory<Cause> {
       id: faker.randomGenerator.integer(100),
       title: faker.lorem.sentence(),
       description: faker.lorem.sentence(),
-      isSelected: faker.randomGenerator.boolean(),
       icon: Icons.place,
       headerImage: ImageFactory().generateBuilder().build(),
     );

--- a/test/factories/learning_resource_factory.dart
+++ b/test/factories/learning_resource_factory.dart
@@ -25,7 +25,6 @@ class LearningResourceFactory extends ModelFactory<LearningResource> {
       type: LearningResourceType.video,
       createdAt: faker.date.dateTime(),
       cause: CauseFactory().generate(),
-      isCompleted: true,
     );
   }
 }


### PR DESCRIPTION
# Description

Currently we store completion info inside resource models. This make its pretty hard to update after users complete more stuff which is what #350 is about. This pulls all completion/joined data from user progress bloc which is updated after each resource is completed and is therefore easy to keep up to date.

Fixes #350 

# Checklist:

## Creator

- [ ] The target branch is main
- [ ] I have updated the unreleased section of the change log
- [ ] I have reviewed the 'files changed' tab on github to ensure all changes are as expected
- [ ] I have added someone to review the pr

## Reviewer

- [ ] I have verified the above are all completed
- [ ] I have run the code locally to ensure it fufills the requirements of the issue
- [ ] I have reviewed the 'files changed' and commented on any sections which I think are not needed, incorrect or could be improved

## After pull

- [ ] If appropriate I have closed the issue/ moved the trello card
